### PR TITLE
host agnostic config option

### DIFF
--- a/packages/jest-mock-environment/README.md
+++ b/packages/jest-mock-environment/README.md
@@ -47,12 +47,12 @@ Example:
 }
 ```
 
-#### shouldUseMocks
+#### isHostAgnostic
 
 Type: `Boolean`
 Default: `false`
 
-If `true` the recorded responses will be used, otherwise the environment records the requests and responses.
+If `true` when using the mocks the host in the URL (including the protocol) won't be used to match the recorded response.
 
 #### isPortAgnostic
 
@@ -60,3 +60,11 @@ Type: `Boolean`
 Default: `false`
 
 If `true` when using the mocks the port in the URL won't be used to match the recorded response.
+
+#### shouldUseMocks
+
+Type: `Boolean`
+Default: `false`
+
+If `true` the recorded responses will be used, otherwise the environment records the requests and responses.
+

--- a/packages/jest-mock-environment/package.json
+++ b/packages/jest-mock-environment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chealt/jest-mock-environment",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "MIT",
   "main": "index.js",
   "repository": {

--- a/packages/jest-mock-environment/package.json
+++ b/packages/jest-mock-environment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chealt/jest-mock-environment",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "license": "MIT",
   "main": "index.js",
   "repository": {

--- a/packages/jest-mock-environment/package.json
+++ b/packages/jest-mock-environment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chealt/jest-mock-environment",
-  "version": "0.4.5",
+  "version": "0.5.0",
   "license": "MIT",
   "main": "index.js",
   "repository": {

--- a/packages/jest-mock-environment/src/envUtils.js
+++ b/packages/jest-mock-environment/src/envUtils.js
@@ -32,9 +32,17 @@ const validateConfig = (config) => {
   } else if (!config.testEnvironmentOptions.mockResponsePath) {
     throw new Error('Please specify where the mocks should be saved to and loaded from using the `mockResponsePath` test environment option.');
   } else {
-    const { rootDir, testEnvironmentOptions: { mockResponsePath, isPortAgnostic, shouldUseMocks } } = config;
+    const {
+      rootDir,
+      testEnvironmentOptions: {
+        mockResponsePath,
+        isHostAgnostic,
+        isPortAgnostic,
+        shouldUseMocks
+      }
+    } = config;
 
-    return { mockResponsePath, isPortAgnostic, rootDir, shouldUseMocks };
+    return { mockResponsePath, isHostAgnostic, isPortAgnostic, rootDir, shouldUseMocks };
   }
 };
 

--- a/packages/jest-mock-environment/src/factory.js
+++ b/packages/jest-mock-environment/src/factory.js
@@ -3,6 +3,8 @@ const factory = async ({ config: configParam, page, mocks, logger } = {}) => {
   const config = {
     dataRequestResourceTypes: ['fetch', 'xhr'],
     notInterceptedUrls: ['browser-sync'],
+    isPortAgnostic: false,
+    shouldUseMocks: false,
     ...configParam
   };
   const responses = {};

--- a/packages/jest-mock-environment/src/factory.js
+++ b/packages/jest-mock-environment/src/factory.js
@@ -1,3 +1,5 @@
+const { findMocksForUrl } = require('./mockUtils');
+
 const factory = async ({ config: configParam, page, mocks, logger } = {}) => {
   let runningTestName;
   const config = {
@@ -8,21 +10,8 @@ const factory = async ({ config: configParam, page, mocks, logger } = {}) => {
     shouldUseMocks: false,
     ...configParam
   };
+  const findMocks = findMocksForUrl(config);
   const responses = {};
-  const removePort = (url) => url.replace(/:\d\d\d\d[\d]*/gu, '');
-  const findMocks = (runningTestMocks, url) => {
-    const { isPortAgnostic } = config;
-
-    const mockKey = Object.keys(runningTestMocks).find(
-      (responseUrl) => (!isPortAgnostic ? responseUrl === url : removePort(responseUrl) === removePort(url))
-    );
-
-    if (mockKey) {
-      return runningTestMocks[mockKey];
-    }
-
-    return undefined;
-  };
   const getMockResponse = ({
     requestDetails: { url, method }
   }) => {

--- a/packages/jest-mock-environment/src/factory.js
+++ b/packages/jest-mock-environment/src/factory.js
@@ -4,6 +4,7 @@ const factory = async ({ config: configParam, page, mocks, logger } = {}) => {
     dataRequestResourceTypes: ['fetch', 'xhr'],
     notInterceptedUrls: ['browser-sync'],
     isPortAgnostic: false,
+    isHostAgnostic: false,
     shouldUseMocks: false,
     ...configParam
   };

--- a/packages/jest-mock-environment/src/index.js
+++ b/packages/jest-mock-environment/src/index.js
@@ -12,13 +12,14 @@ class MockEnvironment extends PuppeteerEnvironment {
   constructor(config) {
     super(config);
 
-    const { mockResponsePath, isPortAgnostic, rootDir, shouldUseMocks } = validateConfig(config);
+    const { mockResponsePath, isHostAgnostic, isPortAgnostic, rootDir, shouldUseMocks } = validateConfig(config);
     const responsesPath = getResponsesPath(rootDir, mockResponsePath);
     setResponsesPath(responsesPath);
 
     this.config = config;
     this.shouldUseMocks = shouldUseMocks;
     this.mocks = shouldUseMocks && getMocks(responsesPath);
+    this.isHostAgnostic = isHostAgnostic;
     this.isPortAgnostic = isPortAgnostic;
   }
 
@@ -33,7 +34,7 @@ class MockEnvironment extends PuppeteerEnvironment {
       page: this.global.page,
       mocks: this.mocks,
       logger,
-      config: { isPortAgnostic: this.isPortAgnostic }
+      config: { isPortAgnostic: this.isPortAgnostic, isHostAgnostic: this.isHostAgnostic }
     });
   }
 

--- a/packages/jest-mock-environment/src/mockUtils.js
+++ b/packages/jest-mock-environment/src/mockUtils.js
@@ -1,0 +1,17 @@
+const removePort = (url) => url.replace(/:\d\d\d\d[\d]*/gu, '');
+
+const findMocksForUrl = ({ isPortAgnostic }) => (mocks, url) => {
+  const mockKey = Object.keys(mocks).find(
+    (responseUrl) => (!isPortAgnostic ? responseUrl === url : removePort(responseUrl) === removePort(url))
+  );
+
+  if (mockKey) {
+    return mocks[mockKey];
+  }
+
+  return undefined;
+};
+
+module.exports = {
+  findMocksForUrl
+};

--- a/packages/jest-mock-environment/src/mockUtils.js
+++ b/packages/jest-mock-environment/src/mockUtils.js
@@ -1,8 +1,19 @@
 const removePort = (url) => url.replace(/:\d\d\d\d[\d]*/gu, '');
+const removeHost = (url) => url.replace(/https?:\/\/[^/]*/gu, '');
 
-const findMocksForUrl = ({ isPortAgnostic }) => (mocks, url) => {
+const findMocksForUrl = ({ isPortAgnostic, isHostAgnostic }) => (mocks, url) => {
   const mockKey = Object.keys(mocks).find(
-    (responseUrl) => (!isPortAgnostic ? responseUrl === url : removePort(responseUrl) === removePort(url))
+    (responseUrl) => {
+      if (isPortAgnostic) {
+        return removePort(responseUrl) === removePort(url);
+      }
+
+      if (isHostAgnostic) {
+        return removeHost(responseUrl) === removeHost(url);
+      }
+
+      return responseUrl === url;
+    }
   );
 
   if (mockKey) {

--- a/packages/jest-puppeteer-mock-preset/package.json
+++ b/packages/jest-puppeteer-mock-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chealt/jest-puppeteer-mock-preset",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   "homepage": "https://github.com/chealt/chealt#chealt",
   "scripts": {},
   "dependencies": {
-    "@chealt/jest-mock-environment": "^0.5.1",
+    "@chealt/jest-mock-environment": "^0.5.2",
     "expect-puppeteer": "^4.4.0",
     "jest-circus": "^26.5.3"
   },

--- a/packages/jest-puppeteer-mock-preset/package.json
+++ b/packages/jest-puppeteer-mock-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chealt/jest-puppeteer-mock-preset",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   "homepage": "https://github.com/chealt/chealt#chealt",
   "scripts": {},
   "dependencies": {
-    "@chealt/jest-mock-environment": "^0.5.0",
+    "@chealt/jest-mock-environment": "^0.5.1",
     "expect-puppeteer": "^4.4.0",
     "jest-circus": "^26.5.3"
   },

--- a/packages/jest-puppeteer-mock-preset/package.json
+++ b/packages/jest-puppeteer-mock-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chealt/jest-puppeteer-mock-preset",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   "homepage": "https://github.com/chealt/chealt#chealt",
   "scripts": {},
   "dependencies": {
-    "@chealt/jest-mock-environment": "^0.4.5",
+    "@chealt/jest-mock-environment": "^0.5.0",
     "expect-puppeteer": "^4.4.0",
     "jest-circus": "^26.5.3"
   },


### PR DESCRIPTION
fixes #28 

The main feature delivered in this PR is adding the option to configure the mock environment not to care about the host of the recorded mock URL when trying to find the mocked response to use.

- [x] add host agnostic config option
- [x] update readme with new config