### PR TITLE
Add more code coverage details

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
     "@babel/core": "^7.12.3",
     "@babel/preset-env": "^7.12.1",
     "babel-eslint": "^10.1.0",
-    "babel-jest": "^26.5.2",
+    "babel-jest": "^26.6.0",
     "eslint": "^7.11.0",
     "eslint-config-prettier": "^6.13.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-prettier": "^3.1.4",
-    "jest": "^26.5.3",
+    "jest": "^26.6.0",
     "prettier": "^2.1.2"
   }
 }

--- a/packages/jest-mock-environment/README.md
+++ b/packages/jest-mock-environment/README.md
@@ -82,6 +82,13 @@ Example:
 }
 ```
 
+#### printCoverageSummary
+
+Type: `Boolean`
+Default: `false`
+
+Indicate if you would like to see the coverage summary in the console after the tests finished executing.
+
 #### recordCoverageText
 
 Type: `Boolean`

--- a/packages/jest-mock-environment/package.json
+++ b/packages/jest-mock-environment/package.json
@@ -10,6 +10,7 @@
   "homepage": "https://github.com/chealt/chealt#chealt",
   "scripts": {},
   "dependencies": {
+    "chalk": "^4.1.0",
     "jest-environment-puppeteer": "^4.4.0"
   },
   "publishConfig": {

--- a/packages/jest-mock-environment/package.json
+++ b/packages/jest-mock-environment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chealt/jest-mock-environment",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "license": "MIT",
   "main": "index.js",
   "repository": {

--- a/packages/jest-mock-environment/src/coverage/index.js
+++ b/packages/jest-mock-environment/src/coverage/index.js
@@ -1,12 +1,12 @@
 const { filterByUrl, removeCoverageText, calculateCoverageDetails } = require('./utils');
-const { getDetailsSummary, printReport } = require('./reporter');
+const { getDetailsReport } = require('./reporter');
 
 const startCollecting = (page) => Promise.all([
   page.coverage.startJSCoverage(),
   page.coverage.startCSSCoverage()
 ]);
 
-const getCoverage = async ({ page, collectCoverageFrom, recordCoverageText, printCoverageSummary, logger }) => {
+const getCoverage = async ({ page, collectCoverageFrom, recordCoverageText }) => {
   const [jsCoverage, cssCoverage] = await Promise.all([
     page.coverage.stopJSCoverage(),
     page.coverage.stopCSSCoverage()
@@ -38,12 +38,12 @@ const getCoverage = async ({ page, collectCoverageFrom, recordCoverageText, prin
     }
   };
 
-  if (printCoverageSummary) {
-    const detailsSummary = getDetailsSummary(details);
-    printReport(detailsSummary, logger);
-  }
+  const report = getDetailsReport(details);
 
-  return details;
+  return {
+    ...details,
+    ...report
+  };
 };
 
 module.exports = {

--- a/packages/jest-mock-environment/src/coverage/index.js
+++ b/packages/jest-mock-environment/src/coverage/index.js
@@ -1,11 +1,12 @@
 const { filterByUrl, removeCoverageText, calculateCoverageDetails } = require('./utils');
+const { getDetailsSummary, printReport } = require('./reporter');
 
 const startCollecting = (page) => Promise.all([
   page.coverage.startJSCoverage(),
   page.coverage.startCSSCoverage()
 ]);
 
-const getCoverage = async ({ page, collectCoverageFrom, recordCoverageText }) => {
+const getCoverage = async ({ page, collectCoverageFrom, recordCoverageText, printCoverageSummary, logger }) => {
   const [jsCoverage, cssCoverage] = await Promise.all([
     page.coverage.stopJSCoverage(),
     page.coverage.stopCSSCoverage()
@@ -27,7 +28,7 @@ const getCoverage = async ({ page, collectCoverageFrom, recordCoverageText }) =>
     finalCSSCoverage = finalCSSCoverage.map(removeCoverageText);
   }
 
-  return {
+  const details = {
     usedBytes,
     totalBytes,
     percentage,
@@ -36,6 +37,13 @@ const getCoverage = async ({ page, collectCoverageFrom, recordCoverageText }) =>
       css: finalCSSCoverage
     }
   };
+
+  if (printCoverageSummary) {
+    const detailsSummary = getDetailsSummary(details);
+    printReport(detailsSummary, logger);
+  }
+
+  return details;
 };
 
 module.exports = {

--- a/packages/jest-mock-environment/src/coverage/reporter.js
+++ b/packages/jest-mock-environment/src/coverage/reporter.js
@@ -20,7 +20,7 @@ const getDownloadTime = (size, speed) => {
       return size / bytesPerSec.GGG;
   }
 };
-const getDetailsSummary = (details) => {
+const getDetailsReport = (details) => {
   const { totalBytes, usedBytes, percentage } = details;
   const totalFormatted = formatSize(totalBytes);
   const totalRawFormatted = formatRawSize(totalBytes);
@@ -54,11 +54,10 @@ const getDetailsSummary = (details) => {
         GGGFormatted: timeSavingsGGGFormatted
       }
     },
-    unusedBytes,
-    ...details
+    unusedBytes
   };
 };
 
 module.exports = {
-  getDetailsSummary
+  getDetailsReport
 };

--- a/packages/jest-mock-environment/src/coverage/reporter.js
+++ b/packages/jest-mock-environment/src/coverage/reporter.js
@@ -1,0 +1,10 @@
+const getDetailsSummary = (details) => details;
+
+const printReport = (details, logger) => {
+  logger.info(details);
+};
+
+module.exports = {
+  getDetailsSummary,
+  printReport
+};

--- a/packages/jest-mock-environment/src/coverage/reporter.js
+++ b/packages/jest-mock-environment/src/coverage/reporter.js
@@ -3,6 +3,23 @@ const formatRawSize = (size) => new Intl.NumberFormat().format(size);
 const formatPercentage = (percentage) => (
   new Intl.NumberFormat(undefined, { style: 'unit', unit: 'percent' }).format(percentage.toFixed(2))
 );
+const formatSeconds = (seconds) => (
+  new Intl.NumberFormat(undefined, { style: 'unit', unit: 'second' }).format(seconds)
+);
+
+const bytesPerSec = {
+  GG: 376 / 8 * 1024,
+  GGG: 1500 / 8 * 1024
+};
+const getDownloadTime = (size, speed) => {
+  switch (speed) {
+    case '2G':
+      return size / bytesPerSec.GG;
+    case '3G':
+    default:
+      return size / bytesPerSec.GGG;
+  }
+};
 const getDetailsSummary = (details) => {
   const { totalBytes, usedBytes, percentage } = details;
   const totalFormatted = formatSize(totalBytes);
@@ -16,6 +33,10 @@ const getDetailsSummary = (details) => {
   const unusedRawFormatted = formatRawSize(unusedBytes);
   const unusedReport = `${unusedFormatted} (${unusedRawFormatted} B)`;
   const percentageFormatted = formatPercentage(percentage);
+  const timeSavingsGG = getDownloadTime(unusedBytes, '2G');
+  const timeSavingsGGFormatted = formatSeconds(timeSavingsGG);
+  const timeSavingsGGG = getDownloadTime(unusedBytes, '3G');
+  const timeSavingsGGGFormatted = formatSeconds(timeSavingsGGG);
 
   return {
     report: {
@@ -25,7 +46,13 @@ const getDetailsSummary = (details) => {
       usedReport,
       unusedFormatted,
       unusedReport,
-      percentageFormatted
+      percentageFormatted,
+      timeSavings: {
+        GG: timeSavingsGG,
+        GGFormatted: timeSavingsGGFormatted,
+        GGG: timeSavingsGGG,
+        GGGFormatted: timeSavingsGGGFormatted
+      }
     },
     unusedBytes,
     ...details

--- a/packages/jest-mock-environment/src/coverage/reporter.js
+++ b/packages/jest-mock-environment/src/coverage/reporter.js
@@ -1,6 +1,8 @@
 const formatSize = (size) => `${(size / 1024 / 1024).toFixed(2)} MB`;
 const formatRawSize = (size) => new Intl.NumberFormat().format(size);
-const formatPercentage = (percentage) => `${percentage.toFixed(2)}%`;
+const formatPercentage = (percentage) => (
+  new Intl.NumberFormat(undefined, { style: 'unit', unit: 'percent' }).format(percentage.toFixed(2))
+);
 const getDetailsSummary = (details) => {
   const { totalBytes, usedBytes, percentage } = details;
   const totalFormatted = formatSize(totalBytes);

--- a/packages/jest-mock-environment/src/coverage/reporter.js
+++ b/packages/jest-mock-environment/src/coverage/reporter.js
@@ -7,17 +7,21 @@ const formatSeconds = (seconds) => (
   new Intl.NumberFormat(undefined, { style: 'unit', unit: 'second' }).format(seconds)
 );
 
-const bytesPerSec = {
-  GG: 376 / 8 * 1024,
-  GGG: 1500 / 8 * 1024
+const KBPerSec = {
+  GG: 30,
+  GGG: 50
+};
+const BPerSec = {
+  GG: KBPerSec.GG * 1024,
+  GGG: KBPerSec.GGG * 1024
 };
 const getDownloadTime = (size, speed) => {
   switch (speed) {
     case '2G':
-      return size / bytesPerSec.GG;
+      return size / BPerSec.GG;
     case '3G':
     default:
-      return size / bytesPerSec.GGG;
+      return size / BPerSec.GGG;
   }
 };
 const getDetailsReport = (details) => {

--- a/packages/jest-mock-environment/src/coverage/reporter.js
+++ b/packages/jest-mock-environment/src/coverage/reporter.js
@@ -11,14 +11,23 @@ const getDetailsSummary = (details) => {
   const usedFormatted = formatSize(usedBytes);
   const usedRawFormatted = formatRawSize(usedBytes);
   const usedReport = `${usedFormatted} (${usedRawFormatted} B)`;
+  const unusedBytes = totalBytes - usedBytes;
+  const unusedFormatted = formatSize(unusedBytes);
+  const unusedRawFormatted = formatRawSize(unusedBytes);
+  const unusedReport = `${unusedFormatted} (${unusedRawFormatted} B)`;
   const percentageFormatted = formatPercentage(percentage);
 
   return {
-    totalFormatted,
-    totalReport,
-    usedFormatted,
-    usedReport,
-    percentageFormatted,
+    report: {
+      totalFormatted,
+      totalReport,
+      usedFormatted,
+      usedReport,
+      unusedFormatted,
+      unusedReport,
+      percentageFormatted
+    },
+    unusedBytes,
     ...details
   };
 };

--- a/packages/jest-mock-environment/src/coverage/reporter.js
+++ b/packages/jest-mock-environment/src/coverage/reporter.js
@@ -1,10 +1,26 @@
-const getDetailsSummary = (details) => details;
+const formatSize = (size) => `${(size / 1024 / 1024).toFixed(2)} MB`;
+const formatRawSize = (size) => new Intl.NumberFormat().format(size);
+const formatPercentage = (percentage) => `${percentage.toFixed(2)}%`;
+const getDetailsSummary = (details) => {
+  const { totalBytes, usedBytes, percentage } = details;
+  const totalFormatted = formatSize(totalBytes);
+  const totalRawFormatted = formatRawSize(totalBytes);
+  const totalReport = `${totalFormatted} (${totalRawFormatted} B)`;
+  const usedFormatted = formatSize(usedBytes);
+  const usedRawFormatted = formatRawSize(usedBytes);
+  const usedReport = `${usedFormatted} (${usedRawFormatted} B)`;
+  const percentageFormatted = formatPercentage(percentage);
 
-const printReport = (details, logger) => {
-  logger.info(details);
+  return {
+    totalFormatted,
+    totalReport,
+    usedFormatted,
+    usedReport,
+    percentageFormatted,
+    ...details
+  };
 };
 
 module.exports = {
-  getDetailsSummary,
-  printReport
+  getDetailsSummary
 };

--- a/packages/jest-mock-environment/src/coverage/utils.js
+++ b/packages/jest-mock-environment/src/coverage/utils.js
@@ -36,8 +36,13 @@ const calculateCoverageDetails = (jsCoverage, cssCoverage) => {
   };
 };
 
+const printCoverages = ({ logger, coverages }) => {
+  logger.info(coverages);
+};
+
 module.exports = {
   calculateCoverageDetails,
   filterByUrl,
+  printCoverages,
   removeCoverageText
 };

--- a/packages/jest-mock-environment/src/coverage/utils.js
+++ b/packages/jest-mock-environment/src/coverage/utils.js
@@ -37,7 +37,16 @@ const calculateCoverageDetails = (jsCoverage, cssCoverage) => {
 };
 
 const printCoverages = ({ logger, coverages }) => {
-  logger.info(coverages);
+  Object.keys(coverages).forEach((testID) => {
+    const { report } = coverages[testID];
+
+    logger.info(`
+${testID}:
+  Total: ${report.totalReport}
+  Unused: ${report.unusedReport}
+  Potential improvement: ${report.timeSavings.GGFormatted} (2G), ${report.timeSavings.GGGFormatted} (3G)
+    `);
+  });
 };
 
 module.exports = {

--- a/packages/jest-mock-environment/src/coverage/utils.js
+++ b/packages/jest-mock-environment/src/coverage/utils.js
@@ -1,3 +1,5 @@
+const { bold, grey, inverse } = require('chalk');
+
 const filterByUrl = (collectCoverageFrom) => ({ url }) => {
   const shouldCollectCoverage = collectCoverageFrom.some((urlRegex) => new RegExp(urlRegex, 'u').test(url));
 
@@ -37,15 +39,16 @@ const calculateCoverageDetails = (jsCoverage, cssCoverage) => {
 };
 
 const printCoverages = ({ logger, coverages }) => {
+  const prefix = inverse.bold(' COVERAGE ');
   Object.keys(coverages).forEach((testID) => {
     const { report } = coverages[testID];
 
     logger.info(`
-${testID}:
-  Total: ${report.totalReport}
-  Unused: ${report.unusedReport}
-  Potential improvement: ${report.timeSavings.GGFormatted} (2G), ${report.timeSavings.GGGFormatted} (3G)
-    `);
+  ${grey(testID)}:
+    ${bold('Total:     ')} ${report.totalReport}
+    ${bold('Unused:    ')} ${report.unusedReport}
+    ${bold('Could save:')} ${report.timeSavings.GGGFormatted} (3G), ${report.timeSavings.GGFormatted} (2G)
+    `, prefix);
   });
 };
 

--- a/packages/jest-mock-environment/src/envUtils.js
+++ b/packages/jest-mock-environment/src/envUtils.js
@@ -41,7 +41,6 @@ const validateConfig = (config) => {
         collectCoverageFrom,
         coverageDirectory,
         mockResponsePath,
-        printCoverageSummary,
         recordCoverageText,
         shouldUseMocks
       }
@@ -52,7 +51,6 @@ const validateConfig = (config) => {
       collectCoverageFrom,
       coverageDirectory,
       mockResponsePath,
-      printCoverageSummary,
       recordCoverageText,
       rootDir,
       shouldUseMocks

--- a/packages/jest-mock-environment/src/envUtils.js
+++ b/packages/jest-mock-environment/src/envUtils.js
@@ -41,6 +41,7 @@ const validateConfig = (config) => {
         collectCoverageFrom,
         coverageDirectory,
         mockResponsePath,
+        printCoverageSummary,
         recordCoverageText,
         shouldUseMocks
       }
@@ -51,6 +52,7 @@ const validateConfig = (config) => {
       collectCoverageFrom,
       coverageDirectory,
       mockResponsePath,
+      printCoverageSummary,
       recordCoverageText,
       rootDir,
       shouldUseMocks

--- a/packages/jest-mock-environment/src/factory.js
+++ b/packages/jest-mock-environment/src/factory.js
@@ -8,6 +8,7 @@ const factory = async ({ config: configParam, page, mocks, logger } = {}) => {
     notInterceptedUrls: ['browser-sync'],
     isPortAgnostic: false,
     isHostAgnostic: false,
+    printCoverageSummary: false,
     recordCoverageText: false,
     shouldUseMocks: false,
     ...configParam
@@ -167,11 +168,18 @@ const factory = async ({ config: configParam, page, mocks, logger } = {}) => {
 
   const getResponses = () => responses;
 
+  // CODE COVERAGE
   const startCollectingCoverage = () => startCollecting(page);
   const stopCollectingCoverage = async () => {
-    const { collectCoverageFrom, recordCoverageText } = config;
+    const { collectCoverageFrom, printCoverageSummary, recordCoverageText } = config;
 
-    coverages[runningTestName] = await getCoverage({ page, collectCoverageFrom, recordCoverageText });
+    coverages[runningTestName] = await getCoverage({
+      page,
+      collectCoverageFrom,
+      recordCoverageText,
+      printCoverageSummary,
+      logger
+    });
   };
   const getCodeCoverages = () => coverages;
 

--- a/packages/jest-mock-environment/src/factory.js
+++ b/packages/jest-mock-environment/src/factory.js
@@ -8,6 +8,7 @@ const factory = async ({ config: configParam, page, mocks, logger } = {}) => {
     notInterceptedUrls: ['browser-sync'],
     isPortAgnostic: false,
     isHostAgnostic: false,
+    printCoverageSummary: false,
     recordCoverageText: false,
     shouldUseMocks: false,
     ...configParam

--- a/packages/jest-mock-environment/src/factory.js
+++ b/packages/jest-mock-environment/src/factory.js
@@ -8,7 +8,6 @@ const factory = async ({ config: configParam, page, mocks, logger } = {}) => {
     notInterceptedUrls: ['browser-sync'],
     isPortAgnostic: false,
     isHostAgnostic: false,
-    printCoverageSummary: false,
     recordCoverageText: false,
     shouldUseMocks: false,
     ...configParam
@@ -171,14 +170,12 @@ const factory = async ({ config: configParam, page, mocks, logger } = {}) => {
   // CODE COVERAGE
   const startCollectingCoverage = () => startCollecting(page);
   const stopCollectingCoverage = async () => {
-    const { collectCoverageFrom, printCoverageSummary, recordCoverageText } = config;
+    const { collectCoverageFrom, recordCoverageText } = config;
 
     coverages[runningTestName] = await getCoverage({
       page,
       collectCoverageFrom,
-      recordCoverageText,
-      printCoverageSummary,
-      logger
+      recordCoverageText
     });
   };
   const getCodeCoverages = () => coverages;

--- a/packages/jest-mock-environment/src/index.js
+++ b/packages/jest-mock-environment/src/index.js
@@ -3,7 +3,7 @@ const PuppeteerEnvironment = require('jest-environment-puppeteer');
 
 const factory = require('./factory');
 const { getLogger, logLevels } = require('./logger');
-const { addCodeCoverages, addTestResponses, setResponsesPath, setCoveragesPath } = require('./state');
+const { addCodeCoverages, addTestResponses, setResponsesPath, setCoveragesPath, setConfig, setLogger } = require('./state');
 const { isTestStartEvent, isTestEndEvent, isTestsEndEvent, getTestID } = require('./testEventUtils');
 const { filterEmptyResponses, getMocks, getFullPath, hasResponses, validateConfig } = require('./envUtils');
 
@@ -24,6 +24,7 @@ class MockEnvironment extends PuppeteerEnvironment {
       this.coverageFullPath = coverageFullPath;
     }
 
+    setConfig(cleanConfig);
     this.config = cleanConfig;
     this.mocks = shouldUseMocks && getMocks(responsesPath);
   }
@@ -40,12 +41,15 @@ class MockEnvironment extends PuppeteerEnvironment {
       collectCoverageFrom,
       isHostAgnostic,
       isPortAgnostic,
+      printCoverageSummary,
       recordCoverageText
     } = this.config;
 
     if (collectCoverage) {
       logger.debug(`Will collect coverage information in: ${this.coverageFullPath}`);
     }
+
+    setLogger(logger);
 
     this.logger = logger;
     this.envInstance = await factory({
@@ -56,6 +60,7 @@ class MockEnvironment extends PuppeteerEnvironment {
         isPortAgnostic,
         isHostAgnostic,
         collectCoverageFrom,
+        printCoverageSummary,
         recordCoverageText
       }
     });

--- a/packages/jest-mock-environment/src/index.js
+++ b/packages/jest-mock-environment/src/index.js
@@ -35,7 +35,14 @@ class MockEnvironment extends PuppeteerEnvironment {
     // Your setup
     logger.debug(`Setting up environemnt with config: ${JSON.stringify(this.config, null, 4)}`);
 
-    const { isHostAgnostic, isPortAgnostic, collectCoverage, collectCoverageFrom, recordCoverageText } = this.config;
+    const {
+      collectCoverage,
+      collectCoverageFrom,
+      isHostAgnostic,
+      isPortAgnostic,
+      printCoverageSummary,
+      recordCoverageText
+    } = this.config;
 
     if (collectCoverage) {
       logger.debug(`Will collect coverage information in: ${this.coverageFullPath}`);
@@ -50,6 +57,7 @@ class MockEnvironment extends PuppeteerEnvironment {
         isPortAgnostic,
         isHostAgnostic,
         collectCoverageFrom,
+        printCoverageSummary,
         recordCoverageText
       }
     });

--- a/packages/jest-mock-environment/src/index.js
+++ b/packages/jest-mock-environment/src/index.js
@@ -40,7 +40,6 @@ class MockEnvironment extends PuppeteerEnvironment {
       collectCoverageFrom,
       isHostAgnostic,
       isPortAgnostic,
-      printCoverageSummary,
       recordCoverageText
     } = this.config;
 
@@ -57,7 +56,6 @@ class MockEnvironment extends PuppeteerEnvironment {
         isPortAgnostic,
         isHostAgnostic,
         collectCoverageFrom,
-        printCoverageSummary,
         recordCoverageText
       }
     });

--- a/packages/jest-mock-environment/src/logger.js
+++ b/packages/jest-mock-environment/src/logger.js
@@ -5,8 +5,8 @@ const logLevels = {
   info: 2,
   warning: 3,
   error: 4,
-  //
-  default: 3
+  // DEFAULT LOG LEVEL
+  default: 2
 };
 
 const getLogger = (level) => {

--- a/packages/jest-mock-environment/src/logger.js
+++ b/packages/jest-mock-environment/src/logger.js
@@ -16,26 +16,26 @@ const getLogger = (level) => {
   return {
     debug:
             level <= logLevels.debug
-              ? (message) => {
-                console.log(chalk.bold.dim(' DEBUG '), chalk.grey(message));
+              ? (message, prefix) => {
+                console.log(prefix ? prefix : chalk.bold.dim(' DEBUG '), chalk.grey(message));
               }
               : noop,
     info:
             level <= logLevels.info
-              ? (message) => {
-                console.log(chalk.bold.inverse(' INFO '), chalk.white(message));
+              ? (message, prefix) => {
+                console.log(prefix ? prefix : chalk.bold.inverse(' INFO '), chalk.white(message));
               }
               : noop,
     warning:
             level <= logLevels.warning
-              ? (message) => {
-                console.log(chalk.bold.bgYellow(' WARN '), chalk.white(message));
+              ? (message, prefix) => {
+                console.log(prefix ? prefix : chalk.bold.bgYellow(' WARN '), chalk.white(message));
               }
               : noop,
     error:
             level <= logLevels.error
-              ? (message) => {
-                console.log(chalk.bold.bgRed(' ERROR '), chalk.white(message));
+              ? (message, prefix) => {
+                console.log(prefix ? prefix : chalk.bold.bgRed(' ERROR '), chalk.white(message));
               }
               : noop
   };

--- a/packages/jest-mock-environment/src/logger.js
+++ b/packages/jest-mock-environment/src/logger.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+const chalk = require('chalk');
 
 const logLevels = {
   debug: 1,
@@ -16,25 +17,25 @@ const getLogger = (level) => {
     debug:
             level <= logLevels.debug
               ? (message) => {
-                console.debug(message);
+                console.log(chalk.bold.dim(' DEBUG '), chalk.grey(message));
               }
               : noop,
     info:
             level <= logLevels.info
               ? (message) => {
-                console.info(message);
+                console.log(chalk.bold.inverse(' INFO '), chalk.white(message));
               }
               : noop,
     warning:
             level <= logLevels.warning
               ? (message) => {
-                console.warn(message);
+                console.log(chalk.bold.bgYellow(' WARN '), chalk.white(message));
               }
               : noop,
     error:
             level <= logLevels.error
               ? (message) => {
-                console.error(message);
+                console.log(chalk.bold.bgRed(' ERROR '), chalk.white(message));
               }
               : noop
   };

--- a/packages/jest-mock-environment/src/state.js
+++ b/packages/jest-mock-environment/src/state.js
@@ -1,12 +1,22 @@
 const fs = require('fs');
 const { promisify } = require('util');
+const coverageUtils = require('./coverage/utils');
 
 const writeFile = promisify(fs.writeFile);
 
 let allResponses = {};
 let allCodeCoverages = {};
+let config = {};
+let logger = {};
 
 const state = () => {
+  // CONFIG
+  const setConfig = (_config) => {
+    config = _config;
+  };
+  const setLogger = (_logger) => {
+    logger = _logger;
+  };
   // RESPONSES
   let responsesPath;
   const saveResponsesFile = (responses) =>
@@ -44,8 +54,15 @@ const state = () => {
       await saveCoveragesFile(allCodeCoverages);
     }
   };
+  const printCoverages = () => {
+    if (config.printCoverageSummary) {
+      coverageUtils.printCoverages({ logger, coverages: allCodeCoverages });
+    }
+  };
 
   return {
+    setConfig,
+    setLogger,
     // RESPONSES
     addTestResponses,
     getResponses,
@@ -54,6 +71,7 @@ const state = () => {
     // COVERAGES
     addCodeCoverages,
     getCoverages,
+    printCoverages,
     saveCoverages,
     setCoveragesPath
   };

--- a/packages/jest-mock-environment/src/teardown.js
+++ b/packages/jest-mock-environment/src/teardown.js
@@ -1,6 +1,6 @@
 const { teardown: teardownPuppeteer } = require('jest-environment-puppeteer');
 
-const { saveResponses, saveCoverages } = require('./state');
+const { saveResponses, saveCoverages, printCoverages } = require('./state');
 
 const { MOCK } = process.env;
 
@@ -10,6 +10,7 @@ const globalTeardown = async (globalConfig) => {
   }
 
   await saveCoverages();
+  printCoverages();
 
   // Your global teardown
   await teardownPuppeteer(globalConfig);

--- a/packages/jest-mock-example/config/jest/jest.puppeteer.config.js
+++ b/packages/jest-mock-example/config/jest/jest.puppeteer.config.js
@@ -8,7 +8,6 @@ module.exports = {
     shouldUseMocks: Boolean(process.env.MOCK),
     collectCoverage: true,
     coverageDirectory: 'coverage',
-    printCoverageSummary: true,
     recordCoverageText: false,
     // eslint-disable-next-line no-useless-escape
     collectCoverageFrom: ['https:\/\/www\.google\.com']

--- a/packages/jest-mock-example/config/jest/jest.puppeteer.config.js
+++ b/packages/jest-mock-example/config/jest/jest.puppeteer.config.js
@@ -8,6 +8,7 @@ module.exports = {
     shouldUseMocks: Boolean(process.env.MOCK),
     collectCoverage: true,
     coverageDirectory: 'coverage',
+    printCoverageSummary: true,
     recordCoverageText: false,
     // eslint-disable-next-line no-useless-escape
     collectCoverageFrom: ['https:\/\/www\.google\.com']

--- a/packages/jest-mock-example/package.json
+++ b/packages/jest-mock-example/package.json
@@ -12,7 +12,7 @@
     "test": "JEST_PUPPETEER_CONFIG=./config/puppeteer/puppeteer.config.js jest --runInBand --config=./config/jest/jest.puppeteer.config.js"
   },
   "dependencies": {
-    "@chealt/jest-puppeteer-mock-preset": "^0.5.2",
+    "@chealt/jest-puppeteer-mock-preset": "^0.6.0",
     "puppeteer": "^5.3.1"
   },
   "peerDependencies": {

--- a/packages/jest-puppeteer-mock-preset/package.json
+++ b/packages/jest-puppeteer-mock-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chealt/jest-puppeteer-mock-preset",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,9 +9,9 @@
   "homepage": "https://github.com/chealt/chealt#chealt",
   "scripts": {},
   "dependencies": {
-    "@chealt/jest-mock-environment": "^0.7.2",
+    "@chealt/jest-mock-environment": "^0.8.0",
     "expect-puppeteer": "^4.4.0",
-    "jest-circus": "^26.5.3"
+    "jest-circus": "^26.6.0"
   },
   "peerDependencies": {
     "puppeteer": "^5.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1061,22 +1061,6 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@chealt/jest-mock-environment@^0.7.2":
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/@chealt/jest-mock-environment/-/jest-mock-environment-0.7.2.tgz#f110aeed83c5333339561e803324725466d8e03a"
-  integrity sha512-pbry4ugVHrYVocnGIRusCOpNFeC1gk8ZMEu+0gDa4EnyAJwsu0RE5Z5SXO79vIdmlMCpG+mBksIkCm3xWeOF3A==
-  dependencies:
-    jest-environment-puppeteer "^4.4.0"
-
-"@chealt/jest-puppeteer-mock-preset@^0.5.2":
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/@chealt/jest-puppeteer-mock-preset/-/jest-puppeteer-mock-preset-0.5.2.tgz#e7b565cbdc6f562da8ee483864ec7c03dd31cefe"
-  integrity sha512-xNWSMYjTlKHzPltv2vlvO3hHpMYAESkX5XnHHpn2hDeCWaeOmv/GYpclQRYT2nqMJwCVt9mnpNuFhclx+j5Jew==
-  dependencies:
-    "@chealt/jest-mock-environment" "^0.7.2"
-    expect-puppeteer "^4.4.0"
-    jest-circus "^26.5.3"
-
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
@@ -1149,18 +1133,6 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
 
-"@jest/console@^26.5.2":
-  version "26.5.2"
-  resolved "https://registry.yarnpkg.com/@jest/console/-/console-26.5.2.tgz#94fc4865b1abed7c352b5e21e6c57be4b95604a6"
-  integrity sha512-lJELzKINpF1v74DXHbCRIkQ/+nUV1M+ntj+X1J8LxCgpmJZjfLmhFejiMSbjjD66fayxl5Z06tbs3HMyuik6rw==
-  dependencies:
-    "@jest/types" "^26.5.2"
-    "@types/node" "*"
-    chalk "^4.0.0"
-    jest-message-util "^26.5.2"
-    jest-util "^26.5.2"
-    slash "^3.0.0"
-
 "@jest/console@^26.6.0":
   version "26.6.0"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-26.6.0.tgz#fd4a4733df3c50260aefb227414296aee96e682f"
@@ -1207,16 +1179,6 @@
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
-"@jest/environment@^26.5.2":
-  version "26.5.2"
-  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-26.5.2.tgz#eba3cfc698f6e03739628f699c28e8a07f5e65fe"
-  integrity sha512-YjhCD/Zhkz0/1vdlS/QN6QmuUdDkpgBdK4SdiVg4Y19e29g4VQYN5Xg8+YuHjdoWGY7wJHMxc79uDTeTOy9Ngw==
-  dependencies:
-    "@jest/fake-timers" "^26.5.2"
-    "@jest/types" "^26.5.2"
-    "@types/node" "*"
-    jest-mock "^26.5.2"
-
 "@jest/environment@^26.6.0":
   version "26.6.0"
   resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-26.6.0.tgz#695ee24cbf110456272caa9debbbf7e01afb2f78"
@@ -1226,18 +1188,6 @@
     "@jest/types" "^26.6.0"
     "@types/node" "*"
     jest-mock "^26.6.0"
-
-"@jest/fake-timers@^26.5.2":
-  version "26.5.2"
-  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-26.5.2.tgz#1291ac81680ceb0dc7daa1f92c059307eea6400a"
-  integrity sha512-09Hn5Oraqt36V1akxQeWMVL0fR9c6PnEhpgLaYvREXZJAh2H2Y+QLCsl0g7uMoJeoWJAuz4tozk1prbR1Fc1sw==
-  dependencies:
-    "@jest/types" "^26.5.2"
-    "@sinonjs/fake-timers" "^6.0.1"
-    "@types/node" "*"
-    jest-message-util "^26.5.2"
-    jest-mock "^26.5.2"
-    jest-util "^26.5.2"
 
 "@jest/fake-timers@^26.6.0":
   version "26.6.0"
@@ -1250,15 +1200,6 @@
     jest-message-util "^26.6.0"
     jest-mock "^26.6.0"
     jest-util "^26.6.0"
-
-"@jest/globals@^26.5.3":
-  version "26.5.3"
-  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-26.5.3.tgz#90769b40e0af3fa0b28f6d8c5bbe3712467243fd"
-  integrity sha512-7QztI0JC2CuB+Wx1VdnOUNeIGm8+PIaqngYsZXQCkH2QV0GFqzAYc9BZfU0nuqA6cbYrWh5wkuMzyii3P7deug==
-  dependencies:
-    "@jest/environment" "^26.5.2"
-    "@jest/types" "^26.5.2"
-    expect "^26.5.3"
 
 "@jest/globals@^26.6.0":
   version "26.6.0"
@@ -1310,16 +1251,6 @@
     graceful-fs "^4.2.4"
     source-map "^0.6.0"
 
-"@jest/test-result@^26.5.2":
-  version "26.5.2"
-  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-26.5.2.tgz#cc1a44cfd4db2ecee3fb0bc4e9fe087aa54b5230"
-  integrity sha512-E/Zp6LURJEGSCWpoMGmCFuuEI1OWuI3hmZwmULV0GsgJBh7u0rwqioxhRU95euUuviqBDN8ruX/vP/4bwYolXw==
-  dependencies:
-    "@jest/console" "^26.5.2"
-    "@jest/types" "^26.5.2"
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    collect-v8-coverage "^1.0.0"
-
 "@jest/test-result@^26.6.0":
   version "26.6.0"
   resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-26.6.0.tgz#79705c8a57165777af5ef1d45c65dcc4a5965c11"
@@ -1329,17 +1260,6 @@
     "@jest/types" "^26.6.0"
     "@types/istanbul-lib-coverage" "^2.0.0"
     collect-v8-coverage "^1.0.0"
-
-"@jest/test-sequencer@^26.5.3":
-  version "26.5.3"
-  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-26.5.3.tgz#9ae0ab9bc37d5171b28424029192e50229814f8d"
-  integrity sha512-Wqzb7aQ13L3T47xHdpUqYMOpiqz6Dx2QDDghp5AV/eUDXR7JieY+E1s233TQlNyl+PqtqgjVokmyjzX/HA51BA==
-  dependencies:
-    "@jest/test-result" "^26.5.2"
-    graceful-fs "^4.2.4"
-    jest-haste-map "^26.5.2"
-    jest-runner "^26.5.3"
-    jest-runtime "^26.5.3"
 
 "@jest/test-sequencer@^26.6.0":
   version "26.6.0"
@@ -1351,27 +1271,6 @@
     jest-haste-map "^26.6.0"
     jest-runner "^26.6.0"
     jest-runtime "^26.6.0"
-
-"@jest/transform@^26.5.2":
-  version "26.5.2"
-  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-26.5.2.tgz#6a0033a1d24316a1c75184d010d864f2c681bef5"
-  integrity sha512-AUNjvexh+APhhmS8S+KboPz+D3pCxPvEAGduffaAJYxIFxGi/ytZQkrqcKDUU0ERBAo5R7087fyOYr2oms1seg==
-  dependencies:
-    "@babel/core" "^7.1.0"
-    "@jest/types" "^26.5.2"
-    babel-plugin-istanbul "^6.0.0"
-    chalk "^4.0.0"
-    convert-source-map "^1.4.0"
-    fast-json-stable-stringify "^2.0.0"
-    graceful-fs "^4.2.4"
-    jest-haste-map "^26.5.2"
-    jest-regex-util "^26.0.0"
-    jest-util "^26.5.2"
-    micromatch "^4.0.2"
-    pirates "^4.0.1"
-    slash "^3.0.0"
-    source-map "^0.6.1"
-    write-file-atomic "^3.0.0"
 
 "@jest/transform@^26.6.0":
   version "26.6.0"
@@ -1393,17 +1292,6 @@
     slash "^3.0.0"
     source-map "^0.6.1"
     write-file-atomic "^3.0.0"
-
-"@jest/types@^26.5.2":
-  version "26.5.2"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.5.2.tgz#44c24f30c8ee6c7f492ead9ec3f3c62a5289756d"
-  integrity sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^3.0.0"
-    "@types/node" "*"
-    "@types/yargs" "^15.0.0"
-    chalk "^4.0.0"
 
 "@jest/types@^26.6.0":
   version "26.6.0"
@@ -1793,20 +1681,6 @@ babel-eslint@^10.1.0:
     "@babel/types" "^7.7.0"
     eslint-visitor-keys "^1.0.0"
     resolve "^1.12.0"
-
-babel-jest@^26.5.2:
-  version "26.5.2"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-26.5.2.tgz#164f367a35946c6cf54eaccde8762dec50422250"
-  integrity sha512-U3KvymF3SczA3vOL/cgiUFOznfMET+XDIXiWnoJV45siAp2pLMG8i2+/MGZlAC3f/F6Q40LR4M4qDrWZ9wkK8A==
-  dependencies:
-    "@jest/transform" "^26.5.2"
-    "@jest/types" "^26.5.2"
-    "@types/babel__core" "^7.1.7"
-    babel-plugin-istanbul "^6.0.0"
-    babel-preset-jest "^26.5.0"
-    chalk "^4.0.0"
-    graceful-fs "^4.2.4"
-    slash "^3.0.0"
 
 babel-jest@^26.6.0:
   version "26.6.0"
@@ -2829,18 +2703,6 @@ expect-puppeteer@^4.4.0:
   resolved "https://registry.yarnpkg.com/expect-puppeteer/-/expect-puppeteer-4.4.0.tgz#1c948af08acdd6c8cbdb7f90e617f44d86888886"
   integrity sha512-6Ey4Xy2xvmuQu7z7YQtMsaMV0EHJRpVxIDOd5GRrm04/I3nkTKIutELfECsLp6le+b3SSa3cXhPiw6PgqzxYWA==
 
-expect@^26.5.3:
-  version "26.5.3"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-26.5.3.tgz#89d9795036f7358b0a9a5243238eb8086482d741"
-  integrity sha512-kkpOhGRWGOr+TEFUnYAjfGvv35bfP+OlPtqPIJpOCR9DVtv8QV+p8zG0Edqafh80fsjeE+7RBcVUq1xApnYglw==
-  dependencies:
-    "@jest/types" "^26.5.2"
-    ansi-styles "^4.0.0"
-    jest-get-type "^26.3.0"
-    jest-matcher-utils "^26.5.2"
-    jest-message-util "^26.5.2"
-    jest-regex-util "^26.0.0"
-
 expect@^26.6.0:
   version "26.6.0"
   resolved "https://registry.yarnpkg.com/expect/-/expect-26.6.0.tgz#f48861317f62bb9f1248eaab7ae9e50a9a5a8339"
@@ -3656,33 +3518,6 @@ jest-changed-files@^26.6.0:
     execa "^4.0.0"
     throat "^5.0.0"
 
-jest-circus@^26.5.3:
-  version "26.5.3"
-  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-26.5.3.tgz#9918231e23bd169d9832b6c23195dab8367fd62d"
-  integrity sha512-d3kCp2ASCG9aq63KZi1VyNDcWCiBwlUfEQfGuKd9aPs45L5J69SsjQjhjAqhVjX0eld8cZMJZS1VC4OuXoQ+8A==
-  dependencies:
-    "@babel/traverse" "^7.1.0"
-    "@jest/environment" "^26.5.2"
-    "@jest/test-result" "^26.5.2"
-    "@jest/types" "^26.5.2"
-    "@types/babel__traverse" "^7.0.4"
-    "@types/node" "*"
-    chalk "^4.0.0"
-    co "^4.6.0"
-    dedent "^0.7.0"
-    expect "^26.5.3"
-    is-generator-fn "^2.0.0"
-    jest-each "^26.5.2"
-    jest-matcher-utils "^26.5.2"
-    jest-message-util "^26.5.2"
-    jest-runner "^26.5.3"
-    jest-runtime "^26.5.3"
-    jest-snapshot "^26.5.3"
-    jest-util "^26.5.2"
-    pretty-format "^26.5.2"
-    stack-utils "^2.0.2"
-    throat "^5.0.0"
-
 jest-circus@^26.6.0:
   version "26.6.0"
   resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-26.6.0.tgz#7d9647b2e7f921181869faae1f90a2629fd70705"
@@ -3729,30 +3564,6 @@ jest-cli@^26.6.0:
     prompts "^2.0.1"
     yargs "^15.4.1"
 
-jest-config@^26.5.3:
-  version "26.5.3"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-26.5.3.tgz#baf51c9be078c2c755c8f8a51ec0f06c762c1d3f"
-  integrity sha512-NVhZiIuN0GQM6b6as4CI5FSCyXKxdrx5ACMCcv/7Pf+TeCajJhJc+6dwgdAVPyerUFB9pRBIz3bE7clSrRge/w==
-  dependencies:
-    "@babel/core" "^7.1.0"
-    "@jest/test-sequencer" "^26.5.3"
-    "@jest/types" "^26.5.2"
-    babel-jest "^26.5.2"
-    chalk "^4.0.0"
-    deepmerge "^4.2.2"
-    glob "^7.1.1"
-    graceful-fs "^4.2.4"
-    jest-environment-jsdom "^26.5.2"
-    jest-environment-node "^26.5.2"
-    jest-get-type "^26.3.0"
-    jest-jasmine2 "^26.5.3"
-    jest-regex-util "^26.0.0"
-    jest-resolve "^26.5.2"
-    jest-util "^26.5.2"
-    jest-validate "^26.5.3"
-    micromatch "^4.0.2"
-    pretty-format "^26.5.2"
-
 jest-config@^26.6.0:
   version "26.6.0"
   resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-26.6.0.tgz#cb879a37002f881edb66d673fd40b6704595de89"
@@ -3790,16 +3601,6 @@ jest-dev-server@^4.4.0:
     tree-kill "^1.2.2"
     wait-on "^3.3.0"
 
-jest-diff@^26.5.2:
-  version "26.5.2"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.5.2.tgz#8e26cb32dc598e8b8a1b9deff55316f8313c8053"
-  integrity sha512-HCSWDUGwsov5oTlGzrRM+UPJI/Dpqi9jzeV0fdRNi3Ch5bnoXhnyJMmVg2juv9081zLIy3HGPI5mcuGgXM2xRA==
-  dependencies:
-    chalk "^4.0.0"
-    diff-sequences "^26.5.0"
-    jest-get-type "^26.3.0"
-    pretty-format "^26.5.2"
-
 jest-diff@^26.6.0:
   version "26.6.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.6.0.tgz#5e5bbbaf93ec5017fae2b3ef12fc895e29988379"
@@ -3817,17 +3618,6 @@ jest-docblock@^26.0.0:
   dependencies:
     detect-newline "^3.0.0"
 
-jest-each@^26.5.2:
-  version "26.5.2"
-  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-26.5.2.tgz#35e68d6906a7f826d3ca5803cfe91d17a5a34c31"
-  integrity sha512-w7D9FNe0m2D3yZ0Drj9CLkyF/mGhmBSULMQTypzAKR746xXnjUrK8GUJdlLTWUF6dd0ks3MtvGP7/xNFr9Aphg==
-  dependencies:
-    "@jest/types" "^26.5.2"
-    chalk "^4.0.0"
-    jest-get-type "^26.3.0"
-    jest-util "^26.5.2"
-    pretty-format "^26.5.2"
-
 jest-each@^26.6.0:
   version "26.6.0"
   resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-26.6.0.tgz#9e9d90a4fc5a79e1d99a008897038325a6c7fbbf"
@@ -3838,19 +3628,6 @@ jest-each@^26.6.0:
     jest-get-type "^26.3.0"
     jest-util "^26.6.0"
     pretty-format "^26.6.0"
-
-jest-environment-jsdom@^26.5.2:
-  version "26.5.2"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-26.5.2.tgz#5feab05b828fd3e4b96bee5e0493464ddd2bb4bc"
-  integrity sha512-fWZPx0bluJaTQ36+PmRpvUtUlUFlGGBNyGX1SN3dLUHHMcQ4WseNEzcGGKOw4U5towXgxI4qDoI3vwR18H0RTw==
-  dependencies:
-    "@jest/environment" "^26.5.2"
-    "@jest/fake-timers" "^26.5.2"
-    "@jest/types" "^26.5.2"
-    "@types/node" "*"
-    jest-mock "^26.5.2"
-    jest-util "^26.5.2"
-    jsdom "^16.4.0"
 
 jest-environment-jsdom@^26.6.0:
   version "26.6.0"
@@ -3864,18 +3641,6 @@ jest-environment-jsdom@^26.6.0:
     jest-mock "^26.6.0"
     jest-util "^26.6.0"
     jsdom "^16.4.0"
-
-jest-environment-node@^26.5.2:
-  version "26.5.2"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-26.5.2.tgz#275a0f01b5e47447056f1541a15ed4da14acca03"
-  integrity sha512-YHjnDsf/GKFCYMGF1V+6HF7jhY1fcLfLNBDjhAOvFGvt6d8vXvNdJGVM7uTZ2VO/TuIyEFhPGaXMX5j3h7fsrA==
-  dependencies:
-    "@jest/environment" "^26.5.2"
-    "@jest/fake-timers" "^26.5.2"
-    "@jest/types" "^26.5.2"
-    "@types/node" "*"
-    jest-mock "^26.5.2"
-    jest-util "^26.5.2"
 
 jest-environment-node@^26.6.0:
   version "26.6.0"
@@ -3904,27 +3669,6 @@ jest-get-type@^26.3.0:
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
   integrity sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==
 
-jest-haste-map@^26.5.2:
-  version "26.5.2"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-26.5.2.tgz#a15008abfc502c18aa56e4919ed8c96304ceb23d"
-  integrity sha512-lJIAVJN3gtO3k4xy+7i2Xjtwh8CfPcH08WYjZpe9xzveDaqGw9fVNCpkYu6M525wKFVkLmyi7ku+DxCAP1lyMA==
-  dependencies:
-    "@jest/types" "^26.5.2"
-    "@types/graceful-fs" "^4.1.2"
-    "@types/node" "*"
-    anymatch "^3.0.3"
-    fb-watchman "^2.0.0"
-    graceful-fs "^4.2.4"
-    jest-regex-util "^26.0.0"
-    jest-serializer "^26.5.0"
-    jest-util "^26.5.2"
-    jest-worker "^26.5.0"
-    micromatch "^4.0.2"
-    sane "^4.0.3"
-    walker "^1.0.7"
-  optionalDependencies:
-    fsevents "^2.1.2"
-
 jest-haste-map@^26.6.0:
   version "26.6.0"
   resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-26.6.0.tgz#4cd392bc51109bd8e0f765b2d5afa746bebb5ce2"
@@ -3945,30 +3689,6 @@ jest-haste-map@^26.6.0:
     walker "^1.0.7"
   optionalDependencies:
     fsevents "^2.1.2"
-
-jest-jasmine2@^26.5.3:
-  version "26.5.3"
-  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-26.5.3.tgz#baad2114ce32d16aff25aeb877d18bb4e332dc4c"
-  integrity sha512-nFlZOpnGlNc7y/+UkkeHnvbOM+rLz4wB1AimgI9QhtnqSZte0wYjbAm8hf7TCwXlXgDwZxAXo6z0a2Wzn9FoOg==
-  dependencies:
-    "@babel/traverse" "^7.1.0"
-    "@jest/environment" "^26.5.2"
-    "@jest/source-map" "^26.5.0"
-    "@jest/test-result" "^26.5.2"
-    "@jest/types" "^26.5.2"
-    "@types/node" "*"
-    chalk "^4.0.0"
-    co "^4.6.0"
-    expect "^26.5.3"
-    is-generator-fn "^2.0.0"
-    jest-each "^26.5.2"
-    jest-matcher-utils "^26.5.2"
-    jest-message-util "^26.5.2"
-    jest-runtime "^26.5.3"
-    jest-snapshot "^26.5.3"
-    jest-util "^26.5.2"
-    pretty-format "^26.5.2"
-    throat "^5.0.0"
 
 jest-jasmine2@^26.6.0:
   version "26.6.0"
@@ -3994,14 +3714,6 @@ jest-jasmine2@^26.6.0:
     pretty-format "^26.6.0"
     throat "^5.0.0"
 
-jest-leak-detector@^26.5.2:
-  version "26.5.2"
-  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-26.5.2.tgz#83fcf9a4a6ef157549552cb4f32ca1d6221eea69"
-  integrity sha512-h7ia3dLzBFItmYERaLPEtEKxy3YlcbcRSjj0XRNJgBEyODuu+3DM2o62kvIFvs3PsaYoIIv+e+nLRI61Dj1CNw==
-  dependencies:
-    jest-get-type "^26.3.0"
-    pretty-format "^26.5.2"
-
 jest-leak-detector@^26.6.0:
   version "26.6.0"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-26.6.0.tgz#a211c4c7627743e8d87b392bf92502cd64275df3"
@@ -4009,16 +3721,6 @@ jest-leak-detector@^26.6.0:
   dependencies:
     jest-get-type "^26.3.0"
     pretty-format "^26.6.0"
-
-jest-matcher-utils@^26.5.2:
-  version "26.5.2"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-26.5.2.tgz#6aa2c76ce8b9c33e66f8856ff3a52bab59e6c85a"
-  integrity sha512-W9GO9KBIC4gIArsNqDUKsLnhivaqf8MSs6ujO/JDcPIQrmY+aasewweXVET8KdrJ6ADQaUne5UzysvF/RR7JYA==
-  dependencies:
-    chalk "^4.0.0"
-    jest-diff "^26.5.2"
-    jest-get-type "^26.3.0"
-    pretty-format "^26.5.2"
 
 jest-matcher-utils@^26.6.0:
   version "26.6.0"
@@ -4029,20 +3731,6 @@ jest-matcher-utils@^26.6.0:
     jest-diff "^26.6.0"
     jest-get-type "^26.3.0"
     pretty-format "^26.6.0"
-
-jest-message-util@^26.5.2:
-  version "26.5.2"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-26.5.2.tgz#6c4c4c46dcfbabb47cd1ba2f6351559729bc11bb"
-  integrity sha512-Ocp9UYZ5Jl15C5PNsoDiGEk14A4NG0zZKknpWdZGoMzJuGAkVt10e97tnEVMYpk7LnQHZOfuK2j/izLBMcuCZw==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@jest/types" "^26.5.2"
-    "@types/stack-utils" "^2.0.0"
-    chalk "^4.0.0"
-    graceful-fs "^4.2.4"
-    micromatch "^4.0.2"
-    slash "^3.0.0"
-    stack-utils "^2.0.2"
 
 jest-message-util@^26.6.0:
   version "26.6.0"
@@ -4057,14 +3745,6 @@ jest-message-util@^26.6.0:
     micromatch "^4.0.2"
     slash "^3.0.0"
     stack-utils "^2.0.2"
-
-jest-mock@^26.5.2:
-  version "26.5.2"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-26.5.2.tgz#c9302e8ef807f2bfc749ee52e65ad11166a1b6a1"
-  integrity sha512-9SiU4b5PtO51v0MtJwVRqeGEroH66Bnwtq4ARdNP7jNXbpT7+ByeWNAk4NeT/uHfNSVDXEXgQo1XRuwEqS6Rdw==
-  dependencies:
-    "@jest/types" "^26.5.2"
-    "@types/node" "*"
 
 jest-mock@^26.6.0:
   version "26.6.0"
@@ -4093,20 +3773,6 @@ jest-resolve-dependencies@^26.6.0:
     jest-regex-util "^26.0.0"
     jest-snapshot "^26.6.0"
 
-jest-resolve@^26.5.2:
-  version "26.5.2"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-26.5.2.tgz#0d719144f61944a428657b755a0e5c6af4fc8602"
-  integrity sha512-XsPxojXGRA0CoDD7Vis59ucz2p3cQFU5C+19tz3tLEAlhYKkK77IL0cjYjikY9wXnOaBeEdm1rOgSJjbZWpcZg==
-  dependencies:
-    "@jest/types" "^26.5.2"
-    chalk "^4.0.0"
-    graceful-fs "^4.2.4"
-    jest-pnp-resolver "^1.2.2"
-    jest-util "^26.5.2"
-    read-pkg-up "^7.0.1"
-    resolve "^1.17.0"
-    slash "^3.0.0"
-
 jest-resolve@^26.6.0:
   version "26.6.0"
   resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-26.6.0.tgz#070fe7159af87b03e50f52ea5e17ee95bbee40e1"
@@ -4120,32 +3786,6 @@ jest-resolve@^26.6.0:
     read-pkg-up "^7.0.1"
     resolve "^1.17.0"
     slash "^3.0.0"
-
-jest-runner@^26.5.3:
-  version "26.5.3"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-26.5.3.tgz#800787459ea59c68e7505952933e33981dc3db38"
-  integrity sha512-qproP0Pq7IIule+263W57k2+8kWCszVJTC9TJWGUz0xJBr+gNiniGXlG8rotd0XxwonD5UiJloYoSO5vbUr5FQ==
-  dependencies:
-    "@jest/console" "^26.5.2"
-    "@jest/environment" "^26.5.2"
-    "@jest/test-result" "^26.5.2"
-    "@jest/types" "^26.5.2"
-    "@types/node" "*"
-    chalk "^4.0.0"
-    emittery "^0.7.1"
-    exit "^0.1.2"
-    graceful-fs "^4.2.4"
-    jest-config "^26.5.3"
-    jest-docblock "^26.0.0"
-    jest-haste-map "^26.5.2"
-    jest-leak-detector "^26.5.2"
-    jest-message-util "^26.5.2"
-    jest-resolve "^26.5.2"
-    jest-runtime "^26.5.3"
-    jest-util "^26.5.2"
-    jest-worker "^26.5.0"
-    source-map-support "^0.5.6"
-    throat "^5.0.0"
 
 jest-runner@^26.6.0:
   version "26.6.0"
@@ -4172,38 +3812,6 @@ jest-runner@^26.6.0:
     jest-worker "^26.5.0"
     source-map-support "^0.5.6"
     throat "^5.0.0"
-
-jest-runtime@^26.5.3:
-  version "26.5.3"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-26.5.3.tgz#5882ae91fd88304310f069549e6bf82f3f198bea"
-  integrity sha512-IDjalmn2s/Tc4GvUwhPHZ0iaXCdMRq5p6taW9P8RpU+FpG01O3+H8z+p3rDCQ9mbyyyviDgxy/LHPLzrIOKBkQ==
-  dependencies:
-    "@jest/console" "^26.5.2"
-    "@jest/environment" "^26.5.2"
-    "@jest/fake-timers" "^26.5.2"
-    "@jest/globals" "^26.5.3"
-    "@jest/source-map" "^26.5.0"
-    "@jest/test-result" "^26.5.2"
-    "@jest/transform" "^26.5.2"
-    "@jest/types" "^26.5.2"
-    "@types/yargs" "^15.0.0"
-    chalk "^4.0.0"
-    collect-v8-coverage "^1.0.0"
-    exit "^0.1.2"
-    glob "^7.1.3"
-    graceful-fs "^4.2.4"
-    jest-config "^26.5.3"
-    jest-haste-map "^26.5.2"
-    jest-message-util "^26.5.2"
-    jest-mock "^26.5.2"
-    jest-regex-util "^26.0.0"
-    jest-resolve "^26.5.2"
-    jest-snapshot "^26.5.3"
-    jest-util "^26.5.2"
-    jest-validate "^26.5.3"
-    slash "^3.0.0"
-    strip-bom "^4.0.0"
-    yargs "^15.4.1"
 
 jest-runtime@^26.6.0:
   version "26.6.0"
@@ -4245,28 +3853,6 @@ jest-serializer@^26.5.0:
     "@types/node" "*"
     graceful-fs "^4.2.4"
 
-jest-snapshot@^26.5.3:
-  version "26.5.3"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-26.5.3.tgz#f6b4b4b845f85d4b0dadd7cf119c55d0c1688601"
-  integrity sha512-ZgAk0Wm0JJ75WS4lGaeRfa0zIgpL0KD595+XmtwlIEMe8j4FaYHyZhP1LNOO+8fXq7HJ3hll54+sFV9X4+CGVw==
-  dependencies:
-    "@babel/types" "^7.0.0"
-    "@jest/types" "^26.5.2"
-    "@types/babel__traverse" "^7.0.4"
-    "@types/prettier" "^2.0.0"
-    chalk "^4.0.0"
-    expect "^26.5.3"
-    graceful-fs "^4.2.4"
-    jest-diff "^26.5.2"
-    jest-get-type "^26.3.0"
-    jest-haste-map "^26.5.2"
-    jest-matcher-utils "^26.5.2"
-    jest-message-util "^26.5.2"
-    jest-resolve "^26.5.2"
-    natural-compare "^1.4.0"
-    pretty-format "^26.5.2"
-    semver "^7.3.2"
-
 jest-snapshot@^26.6.0:
   version "26.6.0"
   resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-26.6.0.tgz#457aa9c1761efc781ac9c02b021a0b21047c6a38"
@@ -4289,18 +3875,6 @@ jest-snapshot@^26.6.0:
     pretty-format "^26.6.0"
     semver "^7.3.2"
 
-jest-util@^26.5.2:
-  version "26.5.2"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.5.2.tgz#8403f75677902cc52a1b2140f568e91f8ed4f4d7"
-  integrity sha512-WTL675bK+GSSAYgS8z9FWdCT2nccO1yTIplNLPlP0OD8tUk/H5IrWKMMRudIQQ0qp8bb4k+1Qa8CxGKq9qnYdg==
-  dependencies:
-    "@jest/types" "^26.5.2"
-    "@types/node" "*"
-    chalk "^4.0.0"
-    graceful-fs "^4.2.4"
-    is-ci "^2.0.0"
-    micromatch "^4.0.2"
-
 jest-util@^26.6.0:
   version "26.6.0"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.6.0.tgz#a81547f6d38738b505c5a594b37d911335dea60f"
@@ -4312,18 +3886,6 @@ jest-util@^26.6.0:
     graceful-fs "^4.2.4"
     is-ci "^2.0.0"
     micromatch "^4.0.2"
-
-jest-validate@^26.5.3:
-  version "26.5.3"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-26.5.3.tgz#eefd5a5c87059550548c5ad8d6589746c66929e3"
-  integrity sha512-LX07qKeAtY+lsU0o3IvfDdN5KH9OulEGOMN1sFo6PnEf5/qjS1LZIwNk9blcBeW94pQUI9dLN9FlDYDWI5tyaA==
-  dependencies:
-    "@jest/types" "^26.5.2"
-    camelcase "^6.0.0"
-    chalk "^4.0.0"
-    jest-get-type "^26.3.0"
-    leven "^3.1.0"
-    pretty-format "^26.5.2"
 
 jest-validate@^26.6.0:
   version "26.6.0"
@@ -5162,16 +4724,6 @@ prettier@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
   integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==
-
-pretty-format@^26.5.2:
-  version "26.5.2"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.5.2.tgz#5d896acfdaa09210683d34b6dc0e6e21423cd3e1"
-  integrity sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==
-  dependencies:
-    "@jest/types" "^26.5.2"
-    ansi-regex "^5.0.0"
-    ansi-styles "^4.0.0"
-    react-is "^16.12.0"
 
 pretty-format@^26.6.0:
   version "26.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1061,6 +1061,22 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@chealt/jest-mock-environment@^0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@chealt/jest-mock-environment/-/jest-mock-environment-0.7.2.tgz#f110aeed83c5333339561e803324725466d8e03a"
+  integrity sha512-pbry4ugVHrYVocnGIRusCOpNFeC1gk8ZMEu+0gDa4EnyAJwsu0RE5Z5SXO79vIdmlMCpG+mBksIkCm3xWeOF3A==
+  dependencies:
+    jest-environment-puppeteer "^4.4.0"
+
+"@chealt/jest-puppeteer-mock-preset@^0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@chealt/jest-puppeteer-mock-preset/-/jest-puppeteer-mock-preset-0.5.2.tgz#e7b565cbdc6f562da8ee483864ec7c03dd31cefe"
+  integrity sha512-xNWSMYjTlKHzPltv2vlvO3hHpMYAESkX5XnHHpn2hDeCWaeOmv/GYpclQRYT2nqMJwCVt9mnpNuFhclx+j5Jew==
+  dependencies:
+    "@chealt/jest-mock-environment" "^0.7.2"
+    expect-puppeteer "^4.4.0"
+    jest-circus "^26.5.3"
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
@@ -1145,34 +1161,46 @@
     jest-util "^26.5.2"
     slash "^3.0.0"
 
-"@jest/core@^26.5.3":
-  version "26.5.3"
-  resolved "https://registry.yarnpkg.com/@jest/core/-/core-26.5.3.tgz#712ed4adb64c3bda256a3f400ff1d3eb2a031f13"
-  integrity sha512-CiU0UKFF1V7KzYTVEtFbFmGLdb2g4aTtY0WlyUfLgj/RtoTnJFhh50xKKr7OYkdmBUlGFSa2mD1TU3UZ6OLd4g==
+"@jest/console@^26.6.0":
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-26.6.0.tgz#fd4a4733df3c50260aefb227414296aee96e682f"
+  integrity sha512-ArGcZWAEYMWmWnc/QvxLDvFmGRPvmHeulhS7FUUAlUGR5vS/SqMfArsGaYmIFEThSotCMnEihwx1h62I1eg5lg==
   dependencies:
-    "@jest/console" "^26.5.2"
-    "@jest/reporters" "^26.5.3"
-    "@jest/test-result" "^26.5.2"
-    "@jest/transform" "^26.5.2"
-    "@jest/types" "^26.5.2"
+    "@jest/types" "^26.6.0"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    jest-message-util "^26.6.0"
+    jest-util "^26.6.0"
+    slash "^3.0.0"
+
+"@jest/core@^26.6.0":
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/@jest/core/-/core-26.6.0.tgz#04dd3e046e9ebbe06a4f330e05a67f21f7bb314a"
+  integrity sha512-7wbunxosnC5zXjxrEtTQSblFjRVOT8qz1eSytw8riEeWgegy3ct91NLPEP440CDuWrmW3cOLcEGxIf9q2u6O9Q==
+  dependencies:
+    "@jest/console" "^26.6.0"
+    "@jest/reporters" "^26.6.0"
+    "@jest/test-result" "^26.6.0"
+    "@jest/transform" "^26.6.0"
+    "@jest/types" "^26.6.0"
     "@types/node" "*"
     ansi-escapes "^4.2.1"
     chalk "^4.0.0"
     exit "^0.1.2"
     graceful-fs "^4.2.4"
-    jest-changed-files "^26.5.2"
-    jest-config "^26.5.3"
-    jest-haste-map "^26.5.2"
-    jest-message-util "^26.5.2"
+    jest-changed-files "^26.6.0"
+    jest-config "^26.6.0"
+    jest-haste-map "^26.6.0"
+    jest-message-util "^26.6.0"
     jest-regex-util "^26.0.0"
-    jest-resolve "^26.5.2"
-    jest-resolve-dependencies "^26.5.3"
-    jest-runner "^26.5.3"
-    jest-runtime "^26.5.3"
-    jest-snapshot "^26.5.3"
-    jest-util "^26.5.2"
-    jest-validate "^26.5.3"
-    jest-watcher "^26.5.2"
+    jest-resolve "^26.6.0"
+    jest-resolve-dependencies "^26.6.0"
+    jest-runner "^26.6.0"
+    jest-runtime "^26.6.0"
+    jest-snapshot "^26.6.0"
+    jest-util "^26.6.0"
+    jest-validate "^26.6.0"
+    jest-watcher "^26.6.0"
     micromatch "^4.0.2"
     p-each-series "^2.1.0"
     rimraf "^3.0.0"
@@ -1189,6 +1217,16 @@
     "@types/node" "*"
     jest-mock "^26.5.2"
 
+"@jest/environment@^26.6.0":
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-26.6.0.tgz#695ee24cbf110456272caa9debbbf7e01afb2f78"
+  integrity sha512-l+5MSdiC4rUUrz8xPdj0TwHBwuoqMcAbFnsYDTn5FkenJl8b+lvC5NdJl1tVICGHWnx0fnjdd1luRZ7u3U4xyg==
+  dependencies:
+    "@jest/fake-timers" "^26.6.0"
+    "@jest/types" "^26.6.0"
+    "@types/node" "*"
+    jest-mock "^26.6.0"
+
 "@jest/fake-timers@^26.5.2":
   version "26.5.2"
   resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-26.5.2.tgz#1291ac81680ceb0dc7daa1f92c059307eea6400a"
@@ -1201,6 +1239,18 @@
     jest-mock "^26.5.2"
     jest-util "^26.5.2"
 
+"@jest/fake-timers@^26.6.0":
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-26.6.0.tgz#5b4cc83fab91029963c53e6e2716f02544323b22"
+  integrity sha512-7VQpjChrwlwvGNysS10lDBLOVLxMvMtpx0Xo6aIotzNVyojYk0NN0CR8R4T6h/eu7Zva/LB3P71jqwGdtADoag==
+  dependencies:
+    "@jest/types" "^26.6.0"
+    "@sinonjs/fake-timers" "^6.0.1"
+    "@types/node" "*"
+    jest-message-util "^26.6.0"
+    jest-mock "^26.6.0"
+    jest-util "^26.6.0"
+
 "@jest/globals@^26.5.3":
   version "26.5.3"
   resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-26.5.3.tgz#90769b40e0af3fa0b28f6d8c5bbe3712467243fd"
@@ -1210,16 +1260,25 @@
     "@jest/types" "^26.5.2"
     expect "^26.5.3"
 
-"@jest/reporters@^26.5.3":
-  version "26.5.3"
-  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-26.5.3.tgz#e810e9c2b670f33f1c09e9975749260ca12f1c17"
-  integrity sha512-X+vR0CpfMQzYcYmMFKNY9n4jklcb14Kffffp7+H/MqitWnb0440bW2L76NGWKAa+bnXhNoZr+lCVtdtPmfJVOQ==
+"@jest/globals@^26.6.0":
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-26.6.0.tgz#da2f58d17105b6a7531ee3c8724acb5f233400e2"
+  integrity sha512-rs3a/a8Lq8FgTx11SxbqIU2bDjsFU2PApl2oK2oUVlo84RSF76afFm2nLojW93AGssr715GHUwhq5b6mpCI5BQ==
+  dependencies:
+    "@jest/environment" "^26.6.0"
+    "@jest/types" "^26.6.0"
+    expect "^26.6.0"
+
+"@jest/reporters@^26.6.0":
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-26.6.0.tgz#2a8d631ad3b19a722fd0fae58ce9fa25e8aac1cf"
+  integrity sha512-PXbvHhdci5Rj1VFloolgLb+0kkdtzswhG8MzVENKJRI3O1ndwr52G6E/2QupjwrRcYnApZOelFf4nNpf5+SDxA==
   dependencies:
     "@bcoe/v8-coverage" "^0.2.3"
-    "@jest/console" "^26.5.2"
-    "@jest/test-result" "^26.5.2"
-    "@jest/transform" "^26.5.2"
-    "@jest/types" "^26.5.2"
+    "@jest/console" "^26.6.0"
+    "@jest/test-result" "^26.6.0"
+    "@jest/transform" "^26.6.0"
+    "@jest/types" "^26.6.0"
     chalk "^4.0.0"
     collect-v8-coverage "^1.0.0"
     exit "^0.1.2"
@@ -1230,9 +1289,9 @@
     istanbul-lib-report "^3.0.0"
     istanbul-lib-source-maps "^4.0.0"
     istanbul-reports "^3.0.2"
-    jest-haste-map "^26.5.2"
-    jest-resolve "^26.5.2"
-    jest-util "^26.5.2"
+    jest-haste-map "^26.6.0"
+    jest-resolve "^26.6.0"
+    jest-util "^26.6.0"
     jest-worker "^26.5.0"
     slash "^3.0.0"
     source-map "^0.6.0"
@@ -1261,6 +1320,16 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     collect-v8-coverage "^1.0.0"
 
+"@jest/test-result@^26.6.0":
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-26.6.0.tgz#79705c8a57165777af5ef1d45c65dcc4a5965c11"
+  integrity sha512-LV6X1ry+sKjseQsIFz3e6XAZYxwidvmeJFnVF08fq98q08dF1mJYI0lDq/LmH/jas+R4s0pwnNGiz1hfC4ZUBw==
+  dependencies:
+    "@jest/console" "^26.6.0"
+    "@jest/types" "^26.6.0"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    collect-v8-coverage "^1.0.0"
+
 "@jest/test-sequencer@^26.5.3":
   version "26.5.3"
   resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-26.5.3.tgz#9ae0ab9bc37d5171b28424029192e50229814f8d"
@@ -1271,6 +1340,17 @@
     jest-haste-map "^26.5.2"
     jest-runner "^26.5.3"
     jest-runtime "^26.5.3"
+
+"@jest/test-sequencer@^26.6.0":
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-26.6.0.tgz#a9dbc6545b1c59e7f375b05466e172126609906d"
+  integrity sha512-rWPTMa+8rejvePZnJmnKkmKWh0qILFDPpN0qbSif+KNGvFxqqDGafMo4P2Y8+I9XWrZQBeXL9IxPL4ZzDgRlbw==
+  dependencies:
+    "@jest/test-result" "^26.6.0"
+    graceful-fs "^4.2.4"
+    jest-haste-map "^26.6.0"
+    jest-runner "^26.6.0"
+    jest-runtime "^26.6.0"
 
 "@jest/transform@^26.5.2":
   version "26.5.2"
@@ -1293,10 +1373,42 @@
     source-map "^0.6.1"
     write-file-atomic "^3.0.0"
 
+"@jest/transform@^26.6.0":
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-26.6.0.tgz#1a6b95d0c7f9b4f96dd3aab9d28422a9e5e4043e"
+  integrity sha512-NUNA1NMCyVV9g5NIQF1jzW7QutQhB/HAocteCiUyH0VhmLXnGMTfPYQu1G6IjPk+k1SWdh2PD+Zs1vMqbavWzg==
+  dependencies:
+    "@babel/core" "^7.1.0"
+    "@jest/types" "^26.6.0"
+    babel-plugin-istanbul "^6.0.0"
+    chalk "^4.0.0"
+    convert-source-map "^1.4.0"
+    fast-json-stable-stringify "^2.0.0"
+    graceful-fs "^4.2.4"
+    jest-haste-map "^26.6.0"
+    jest-regex-util "^26.0.0"
+    jest-util "^26.6.0"
+    micromatch "^4.0.2"
+    pirates "^4.0.1"
+    slash "^3.0.0"
+    source-map "^0.6.1"
+    write-file-atomic "^3.0.0"
+
 "@jest/types@^26.5.2":
   version "26.5.2"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.5.2.tgz#44c24f30c8ee6c7f492ead9ec3f3c62a5289756d"
   integrity sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
+
+"@jest/types@^26.6.0":
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.0.tgz#2c045f231bfd79d52514cda3fbc93ef46157fa6a"
+  integrity sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==
   dependencies:
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^3.0.0"
@@ -1689,6 +1801,20 @@ babel-jest@^26.5.2:
   dependencies:
     "@jest/transform" "^26.5.2"
     "@jest/types" "^26.5.2"
+    "@types/babel__core" "^7.1.7"
+    babel-plugin-istanbul "^6.0.0"
+    babel-preset-jest "^26.5.0"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.4"
+    slash "^3.0.0"
+
+babel-jest@^26.6.0:
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-26.6.0.tgz#eca57ac8af99d6e06047e595b1faf0b5adf8a7bb"
+  integrity sha512-JI66yILI7stzjHccAoQtRKcUwJrJb4oMIxLTirL3GdAjGpaUBQSjZDFi9LsPkN4gftsS4R2AThAJwOjJxadwbg==
+  dependencies:
+    "@jest/transform" "^26.6.0"
+    "@jest/types" "^26.6.0"
     "@types/babel__core" "^7.1.7"
     babel-plugin-istanbul "^6.0.0"
     babel-preset-jest "^26.5.0"
@@ -2715,6 +2841,18 @@ expect@^26.5.3:
     jest-message-util "^26.5.2"
     jest-regex-util "^26.0.0"
 
+expect@^26.6.0:
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-26.6.0.tgz#f48861317f62bb9f1248eaab7ae9e50a9a5a8339"
+  integrity sha512-EzhbZ1tbwcaa5Ok39BI11flIMeIUSlg1QsnXOrleaMvltwHsvIQPBtL710l+ma+qDFLUgktCXK4YuQzmHdm7cg==
+  dependencies:
+    "@jest/types" "^26.6.0"
+    ansi-styles "^4.0.0"
+    jest-get-type "^26.3.0"
+    jest-matcher-utils "^26.6.0"
+    jest-message-util "^26.6.0"
+    jest-regex-util "^26.0.0"
+
 extend-shallow@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
@@ -3509,12 +3647,12 @@ istanbul-reports@^3.0.2:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-jest-changed-files@^26.5.2:
-  version "26.5.2"
-  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-26.5.2.tgz#330232c6a5c09a7f040a5870e8f0a9c6abcdbed5"
-  integrity sha512-qSmssmiIdvM5BWVtyK/nqVpN3spR5YyvkvPqz1x3BR1bwIxsWmU/MGwLoCrPNLbkG2ASAKfvmJpOduEApBPh2w==
+jest-changed-files@^26.6.0:
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-26.6.0.tgz#63b04aa261b5733c6ade96b7dd24784d12d8bb2d"
+  integrity sha512-k8PZzlp3cRWDe0fDc/pYs+c4w36+hiWXe1PpW/pW1UJmu1TNTAcQfZUrVYleij+uEqlY6z4mPv7Iff3kY0o5SQ==
   dependencies:
-    "@jest/types" "^26.5.2"
+    "@jest/types" "^26.6.0"
     execa "^4.0.0"
     throat "^5.0.0"
 
@@ -3545,22 +3683,49 @@ jest-circus@^26.5.3:
     stack-utils "^2.0.2"
     throat "^5.0.0"
 
-jest-cli@^26.5.3:
-  version "26.5.3"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-26.5.3.tgz#f936b98f247b76b7bc89c7af50af82c88e356a80"
-  integrity sha512-HkbSvtugpSXBf2660v9FrNVUgxvPkssN8CRGj9gPM8PLhnaa6zziFiCEKQAkQS4uRzseww45o0TR+l6KeRYV9A==
+jest-circus@^26.6.0:
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-26.6.0.tgz#7d9647b2e7f921181869faae1f90a2629fd70705"
+  integrity sha512-L2/Y9szN6FJPWFK8kzWXwfp+FOR7xq0cUL4lIsdbIdwz3Vh6P1nrpcqOleSzr28zOtSHQNV9Z7Tl+KkuK7t5Ng==
   dependencies:
-    "@jest/core" "^26.5.3"
-    "@jest/test-result" "^26.5.2"
-    "@jest/types" "^26.5.2"
+    "@babel/traverse" "^7.1.0"
+    "@jest/environment" "^26.6.0"
+    "@jest/test-result" "^26.6.0"
+    "@jest/types" "^26.6.0"
+    "@types/babel__traverse" "^7.0.4"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    co "^4.6.0"
+    dedent "^0.7.0"
+    expect "^26.6.0"
+    is-generator-fn "^2.0.0"
+    jest-each "^26.6.0"
+    jest-matcher-utils "^26.6.0"
+    jest-message-util "^26.6.0"
+    jest-runner "^26.6.0"
+    jest-runtime "^26.6.0"
+    jest-snapshot "^26.6.0"
+    jest-util "^26.6.0"
+    pretty-format "^26.6.0"
+    stack-utils "^2.0.2"
+    throat "^5.0.0"
+
+jest-cli@^26.6.0:
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-26.6.0.tgz#dc3ae34fd5937310493ed07dc79c5ffba2bf6671"
+  integrity sha512-lJAMZGpmML+y3Kfln6L5DGRTfKGQ+n1JDM1RQstojSLUhe/EaXWR8vmcx70v4CyJKvFZs7c/0QDkPX5ra/aDew==
+  dependencies:
+    "@jest/core" "^26.6.0"
+    "@jest/test-result" "^26.6.0"
+    "@jest/types" "^26.6.0"
     chalk "^4.0.0"
     exit "^0.1.2"
     graceful-fs "^4.2.4"
     import-local "^3.0.2"
     is-ci "^2.0.0"
-    jest-config "^26.5.3"
-    jest-util "^26.5.2"
-    jest-validate "^26.5.3"
+    jest-config "^26.6.0"
+    jest-util "^26.6.0"
+    jest-validate "^26.6.0"
     prompts "^2.0.1"
     yargs "^15.4.1"
 
@@ -3588,6 +3753,30 @@ jest-config@^26.5.3:
     micromatch "^4.0.2"
     pretty-format "^26.5.2"
 
+jest-config@^26.6.0:
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-26.6.0.tgz#cb879a37002f881edb66d673fd40b6704595de89"
+  integrity sha512-RCR1Kf7MGJ5waVCvrj/k3nCAJKquWZlzs8rkskzj0KlG392hNBOaYd5FQ4cCac08j6pwfIDOwNvMcy0/FqguJg==
+  dependencies:
+    "@babel/core" "^7.1.0"
+    "@jest/test-sequencer" "^26.6.0"
+    "@jest/types" "^26.6.0"
+    babel-jest "^26.6.0"
+    chalk "^4.0.0"
+    deepmerge "^4.2.2"
+    glob "^7.1.1"
+    graceful-fs "^4.2.4"
+    jest-environment-jsdom "^26.6.0"
+    jest-environment-node "^26.6.0"
+    jest-get-type "^26.3.0"
+    jest-jasmine2 "^26.6.0"
+    jest-regex-util "^26.0.0"
+    jest-resolve "^26.6.0"
+    jest-util "^26.6.0"
+    jest-validate "^26.6.0"
+    micromatch "^4.0.2"
+    pretty-format "^26.6.0"
+
 jest-dev-server@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/jest-dev-server/-/jest-dev-server-4.4.0.tgz#557113faae2877452162696aa94c1e44491ab011"
@@ -3611,6 +3800,16 @@ jest-diff@^26.5.2:
     jest-get-type "^26.3.0"
     pretty-format "^26.5.2"
 
+jest-diff@^26.6.0:
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.6.0.tgz#5e5bbbaf93ec5017fae2b3ef12fc895e29988379"
+  integrity sha512-IH09rKsdWY8YEY7ii2BHlSq59oXyF2pK3GoK+hOK9eD/x6009eNB5Jv1shLMKgxekodPzLlV7eZP1jPFQYds8w==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^26.5.0"
+    jest-get-type "^26.3.0"
+    pretty-format "^26.6.0"
+
 jest-docblock@^26.0.0:
   version "26.0.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-26.0.0.tgz#3e2fa20899fc928cb13bd0ff68bd3711a36889b5"
@@ -3629,6 +3828,17 @@ jest-each@^26.5.2:
     jest-util "^26.5.2"
     pretty-format "^26.5.2"
 
+jest-each@^26.6.0:
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-26.6.0.tgz#9e9d90a4fc5a79e1d99a008897038325a6c7fbbf"
+  integrity sha512-7LzSNwNviYnm4FWK46itIE03NqD/8O8/7tVQ5rwTdTNrmPMQoQ1Z7hEFQ1uzRReluOFislpurpnQ0QsclSiDkA==
+  dependencies:
+    "@jest/types" "^26.6.0"
+    chalk "^4.0.0"
+    jest-get-type "^26.3.0"
+    jest-util "^26.6.0"
+    pretty-format "^26.6.0"
+
 jest-environment-jsdom@^26.5.2:
   version "26.5.2"
   resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-26.5.2.tgz#5feab05b828fd3e4b96bee5e0493464ddd2bb4bc"
@@ -3642,6 +3852,19 @@ jest-environment-jsdom@^26.5.2:
     jest-util "^26.5.2"
     jsdom "^16.4.0"
 
+jest-environment-jsdom@^26.6.0:
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-26.6.0.tgz#2ce353fb82d27a9066bfea3ff2c27d9405076c69"
+  integrity sha512-bXO9IG7a3YlyiHxwfKF+OWoTA+GIw4FrD+Y0pb6CC+nKs5JuSRZmR2ovEX6PWo6KY42ka3JoZOp3KEnXiFPPCg==
+  dependencies:
+    "@jest/environment" "^26.6.0"
+    "@jest/fake-timers" "^26.6.0"
+    "@jest/types" "^26.6.0"
+    "@types/node" "*"
+    jest-mock "^26.6.0"
+    jest-util "^26.6.0"
+    jsdom "^16.4.0"
+
 jest-environment-node@^26.5.2:
   version "26.5.2"
   resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-26.5.2.tgz#275a0f01b5e47447056f1541a15ed4da14acca03"
@@ -3653,6 +3876,18 @@ jest-environment-node@^26.5.2:
     "@types/node" "*"
     jest-mock "^26.5.2"
     jest-util "^26.5.2"
+
+jest-environment-node@^26.6.0:
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-26.6.0.tgz#97f6e48085e67bda43b97f48e678ce78d760cd14"
+  integrity sha512-kWU6ZD1h6fs7sIl6ufuK0sXW/3d6WLaj48iow0NxhgU6eY89d9K+0MVmE0cRcVlh53yMyxTK6b+TnhLOnlGp/A==
+  dependencies:
+    "@jest/environment" "^26.6.0"
+    "@jest/fake-timers" "^26.6.0"
+    "@jest/types" "^26.6.0"
+    "@types/node" "*"
+    jest-mock "^26.6.0"
+    jest-util "^26.6.0"
 
 jest-environment-puppeteer@^4.4.0:
   version "4.4.0"
@@ -3690,6 +3925,27 @@ jest-haste-map@^26.5.2:
   optionalDependencies:
     fsevents "^2.1.2"
 
+jest-haste-map@^26.6.0:
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-26.6.0.tgz#4cd392bc51109bd8e0f765b2d5afa746bebb5ce2"
+  integrity sha512-RpNqAGMR58uG9E9vWITorX2/R7he/tSbHWldX5upt1ymEcmCaXczqXxjqI6xOtRR8Ev6ZEYDfgSA5Fy7WHUL5w==
+  dependencies:
+    "@jest/types" "^26.6.0"
+    "@types/graceful-fs" "^4.1.2"
+    "@types/node" "*"
+    anymatch "^3.0.3"
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.2.4"
+    jest-regex-util "^26.0.0"
+    jest-serializer "^26.5.0"
+    jest-util "^26.6.0"
+    jest-worker "^26.5.0"
+    micromatch "^4.0.2"
+    sane "^4.0.3"
+    walker "^1.0.7"
+  optionalDependencies:
+    fsevents "^2.1.2"
+
 jest-jasmine2@^26.5.3:
   version "26.5.3"
   resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-26.5.3.tgz#baad2114ce32d16aff25aeb877d18bb4e332dc4c"
@@ -3714,6 +3970,30 @@ jest-jasmine2@^26.5.3:
     pretty-format "^26.5.2"
     throat "^5.0.0"
 
+jest-jasmine2@^26.6.0:
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-26.6.0.tgz#1b59e26aa56651bae3d4637965c8cd4d3851de6d"
+  integrity sha512-2E3c+0A9y2OIK5caw5qlcm3b4doaf8FSfXKTX3xqKTUJoR4zXh0xvERBNWxZP9xMNXEi/2Z3LVsZpR2hROgixA==
+  dependencies:
+    "@babel/traverse" "^7.1.0"
+    "@jest/environment" "^26.6.0"
+    "@jest/source-map" "^26.5.0"
+    "@jest/test-result" "^26.6.0"
+    "@jest/types" "^26.6.0"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    co "^4.6.0"
+    expect "^26.6.0"
+    is-generator-fn "^2.0.0"
+    jest-each "^26.6.0"
+    jest-matcher-utils "^26.6.0"
+    jest-message-util "^26.6.0"
+    jest-runtime "^26.6.0"
+    jest-snapshot "^26.6.0"
+    jest-util "^26.6.0"
+    pretty-format "^26.6.0"
+    throat "^5.0.0"
+
 jest-leak-detector@^26.5.2:
   version "26.5.2"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-26.5.2.tgz#83fcf9a4a6ef157549552cb4f32ca1d6221eea69"
@@ -3721,6 +4001,14 @@ jest-leak-detector@^26.5.2:
   dependencies:
     jest-get-type "^26.3.0"
     pretty-format "^26.5.2"
+
+jest-leak-detector@^26.6.0:
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-26.6.0.tgz#a211c4c7627743e8d87b392bf92502cd64275df3"
+  integrity sha512-3oMv34imWTl1/nwKnmE/DxYo3QqHnZeF3nO6UzldppkhW0Za7OY2DYyWiamqVzwdUrjhoQkY5g+aF6Oc3alYEQ==
+  dependencies:
+    jest-get-type "^26.3.0"
+    pretty-format "^26.6.0"
 
 jest-matcher-utils@^26.5.2:
   version "26.5.2"
@@ -3731,6 +4019,16 @@ jest-matcher-utils@^26.5.2:
     jest-diff "^26.5.2"
     jest-get-type "^26.3.0"
     pretty-format "^26.5.2"
+
+jest-matcher-utils@^26.6.0:
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-26.6.0.tgz#8f57d78353275bfa7a3ccea128c1030b347138e2"
+  integrity sha512-BUy/dQYb7ELGRazmK4ZVkbfPYCaNnrMtw1YljVhcKzWUxBM0xQ+bffrfnMLdRZp4wUUcT4ahaVnA3VWZtXWP9Q==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^26.6.0"
+    jest-get-type "^26.3.0"
+    pretty-format "^26.6.0"
 
 jest-message-util@^26.5.2:
   version "26.5.2"
@@ -3746,12 +4044,34 @@ jest-message-util@^26.5.2:
     slash "^3.0.0"
     stack-utils "^2.0.2"
 
+jest-message-util@^26.6.0:
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-26.6.0.tgz#c3499053022e05765f71b8c2535af63009e2d4be"
+  integrity sha512-WPAeS38Kza29f04I0iOIQrXeiebRXjmn6cFehzI7KKJOgT0NmqYAcLgjWnIAfKs5FBmEQgje1kXab0DaLKCl2w==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@jest/types" "^26.6.0"
+    "@types/stack-utils" "^2.0.0"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.4"
+    micromatch "^4.0.2"
+    slash "^3.0.0"
+    stack-utils "^2.0.2"
+
 jest-mock@^26.5.2:
   version "26.5.2"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-26.5.2.tgz#c9302e8ef807f2bfc749ee52e65ad11166a1b6a1"
   integrity sha512-9SiU4b5PtO51v0MtJwVRqeGEroH66Bnwtq4ARdNP7jNXbpT7+ByeWNAk4NeT/uHfNSVDXEXgQo1XRuwEqS6Rdw==
   dependencies:
     "@jest/types" "^26.5.2"
+    "@types/node" "*"
+
+jest-mock@^26.6.0:
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-26.6.0.tgz#5d13a41f3662a98a55c7742ac67c482e232ded13"
+  integrity sha512-HsNmL8vVIn1rL1GWA21Drpy9Cl+7GImwbWz/0fkWHrUXVzuaG7rP0vwLtE+/n70Mt0U8nPkz8fxioi3SC0wqhw==
+  dependencies:
+    "@jest/types" "^26.6.0"
     "@types/node" "*"
 
 jest-pnp-resolver@^1.2.2:
@@ -3764,14 +4084,14 @@ jest-regex-util@^26.0.0:
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-26.0.0.tgz#d25e7184b36e39fd466c3bc41be0971e821fee28"
   integrity sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==
 
-jest-resolve-dependencies@^26.5.3:
-  version "26.5.3"
-  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-26.5.3.tgz#11483f91e534bdcd257ab21e8622799e59701aba"
-  integrity sha512-+KMDeke/BFK+mIQ2IYSyBz010h7zQaVt4Xie6cLqUGChorx66vVeQVv4ErNoMwInnyYHi1Ud73tDS01UbXbfLQ==
+jest-resolve-dependencies@^26.6.0:
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-26.6.0.tgz#05bfecc977a3a48929fc7d9876f03d93a16b7df0"
+  integrity sha512-4di+XUT7LwJJ8b8qFEEDQssC5+aeVjLhvRICCaS4alh/EVS9JCT1armfJ3pnSS8t4o6659WbMmKVo82H4LuUVw==
   dependencies:
-    "@jest/types" "^26.5.2"
+    "@jest/types" "^26.6.0"
     jest-regex-util "^26.0.0"
-    jest-snapshot "^26.5.3"
+    jest-snapshot "^26.6.0"
 
 jest-resolve@^26.5.2:
   version "26.5.2"
@@ -3783,6 +4103,20 @@ jest-resolve@^26.5.2:
     graceful-fs "^4.2.4"
     jest-pnp-resolver "^1.2.2"
     jest-util "^26.5.2"
+    read-pkg-up "^7.0.1"
+    resolve "^1.17.0"
+    slash "^3.0.0"
+
+jest-resolve@^26.6.0:
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-26.6.0.tgz#070fe7159af87b03e50f52ea5e17ee95bbee40e1"
+  integrity sha512-tRAz2bwraHufNp+CCmAD8ciyCpXCs1NQxB5EJAmtCFy6BN81loFEGWKzYu26Y62lAJJe4X4jg36Kf+NsQyiStQ==
+  dependencies:
+    "@jest/types" "^26.6.0"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.4"
+    jest-pnp-resolver "^1.2.2"
+    jest-util "^26.6.0"
     read-pkg-up "^7.0.1"
     resolve "^1.17.0"
     slash "^3.0.0"
@@ -3809,6 +4143,32 @@ jest-runner@^26.5.3:
     jest-resolve "^26.5.2"
     jest-runtime "^26.5.3"
     jest-util "^26.5.2"
+    jest-worker "^26.5.0"
+    source-map-support "^0.5.6"
+    throat "^5.0.0"
+
+jest-runner@^26.6.0:
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-26.6.0.tgz#465a76efc9ec12cfd83a2af3a6cfb695b13a3efe"
+  integrity sha512-QpeN6pje8PQvFgT+wYOlzeycKd67qAvSw5FgYBiX2cTW+QTiObTzv/k09qRvT09rcCntFxUhy9VB1mgNGFLYIA==
+  dependencies:
+    "@jest/console" "^26.6.0"
+    "@jest/environment" "^26.6.0"
+    "@jest/test-result" "^26.6.0"
+    "@jest/types" "^26.6.0"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    emittery "^0.7.1"
+    exit "^0.1.2"
+    graceful-fs "^4.2.4"
+    jest-config "^26.6.0"
+    jest-docblock "^26.0.0"
+    jest-haste-map "^26.6.0"
+    jest-leak-detector "^26.6.0"
+    jest-message-util "^26.6.0"
+    jest-resolve "^26.6.0"
+    jest-runtime "^26.6.0"
+    jest-util "^26.6.0"
     jest-worker "^26.5.0"
     source-map-support "^0.5.6"
     throat "^5.0.0"
@@ -3845,6 +4205,38 @@ jest-runtime@^26.5.3:
     strip-bom "^4.0.0"
     yargs "^15.4.1"
 
+jest-runtime@^26.6.0:
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-26.6.0.tgz#90f80ea5eb0d97a1089120f582fb84bd36ca5491"
+  integrity sha512-JEz4YGnybFvtN4NLID6lsZf0bcd8jccwjWcG5TRE3fYVnxoX1egTthPjnC4btIwWJ6QaaHhtOQ/E3AGn8iClAw==
+  dependencies:
+    "@jest/console" "^26.6.0"
+    "@jest/environment" "^26.6.0"
+    "@jest/fake-timers" "^26.6.0"
+    "@jest/globals" "^26.6.0"
+    "@jest/source-map" "^26.5.0"
+    "@jest/test-result" "^26.6.0"
+    "@jest/transform" "^26.6.0"
+    "@jest/types" "^26.6.0"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
+    collect-v8-coverage "^1.0.0"
+    exit "^0.1.2"
+    glob "^7.1.3"
+    graceful-fs "^4.2.4"
+    jest-config "^26.6.0"
+    jest-haste-map "^26.6.0"
+    jest-message-util "^26.6.0"
+    jest-mock "^26.6.0"
+    jest-regex-util "^26.0.0"
+    jest-resolve "^26.6.0"
+    jest-snapshot "^26.6.0"
+    jest-util "^26.6.0"
+    jest-validate "^26.6.0"
+    slash "^3.0.0"
+    strip-bom "^4.0.0"
+    yargs "^15.4.1"
+
 jest-serializer@^26.5.0:
   version "26.5.0"
   resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-26.5.0.tgz#f5425cc4c5f6b4b355f854b5f0f23ec6b962bc13"
@@ -3875,12 +4267,46 @@ jest-snapshot@^26.5.3:
     pretty-format "^26.5.2"
     semver "^7.3.2"
 
+jest-snapshot@^26.6.0:
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-26.6.0.tgz#457aa9c1761efc781ac9c02b021a0b21047c6a38"
+  integrity sha512-mcqJZeIZqxomvBcsaiIbiEe2g7K1UxnUpTwjMoHb+DX4uFGnuZoZ6m28YOYRyCfZsdU9mmq73rNBnEH2atTR4Q==
+  dependencies:
+    "@babel/types" "^7.0.0"
+    "@jest/types" "^26.6.0"
+    "@types/babel__traverse" "^7.0.4"
+    "@types/prettier" "^2.0.0"
+    chalk "^4.0.0"
+    expect "^26.6.0"
+    graceful-fs "^4.2.4"
+    jest-diff "^26.6.0"
+    jest-get-type "^26.3.0"
+    jest-haste-map "^26.6.0"
+    jest-matcher-utils "^26.6.0"
+    jest-message-util "^26.6.0"
+    jest-resolve "^26.6.0"
+    natural-compare "^1.4.0"
+    pretty-format "^26.6.0"
+    semver "^7.3.2"
+
 jest-util@^26.5.2:
   version "26.5.2"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.5.2.tgz#8403f75677902cc52a1b2140f568e91f8ed4f4d7"
   integrity sha512-WTL675bK+GSSAYgS8z9FWdCT2nccO1yTIplNLPlP0OD8tUk/H5IrWKMMRudIQQ0qp8bb4k+1Qa8CxGKq9qnYdg==
   dependencies:
     "@jest/types" "^26.5.2"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.4"
+    is-ci "^2.0.0"
+    micromatch "^4.0.2"
+
+jest-util@^26.6.0:
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.6.0.tgz#a81547f6d38738b505c5a594b37d911335dea60f"
+  integrity sha512-/cUGqcnKeZMjvTQLfJo65nBOEZ/k0RB/8usv2JpfYya05u0XvBmKkIH5o5c4nCh9DD61B1YQjMGGqh1Ha0aXdg==
+  dependencies:
+    "@jest/types" "^26.6.0"
     "@types/node" "*"
     chalk "^4.0.0"
     graceful-fs "^4.2.4"
@@ -3899,17 +4325,29 @@ jest-validate@^26.5.3:
     leven "^3.1.0"
     pretty-format "^26.5.2"
 
-jest-watcher@^26.5.2:
-  version "26.5.2"
-  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-26.5.2.tgz#2957f4461007e0769d74b537379ecf6b7c696916"
-  integrity sha512-i3m1NtWzF+FXfJ3ljLBB/WQEp4uaNhX7QcQUWMokcifFTUQBDFyUMEwk0JkJ1kopHbx7Een3KX0Q7+9koGM/Pw==
+jest-validate@^26.6.0:
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-26.6.0.tgz#b95e2076cca1a58b183e5bcce2bf43af52eebf10"
+  integrity sha512-FKHNqvh1Pgs4NWas56gsTPmjcIoGAAzSVUCK1+g8euzuCGbmdEr8LRTtOEFjd29uMZUk0PhzmzKGlHPe6j3UWw==
   dependencies:
-    "@jest/test-result" "^26.5.2"
-    "@jest/types" "^26.5.2"
+    "@jest/types" "^26.6.0"
+    camelcase "^6.0.0"
+    chalk "^4.0.0"
+    jest-get-type "^26.3.0"
+    leven "^3.1.0"
+    pretty-format "^26.6.0"
+
+jest-watcher@^26.6.0:
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-26.6.0.tgz#06001c22831583a16f9ccb388ee33316a7f4200f"
+  integrity sha512-gw5BvcgPi0PKpMlNWQjUet5C5A4JOYrT7gexdP6+DR/f7mRm7wE0o1GqwPwcTsTwo0/FNf9c/kIDXTRaSAYwlw==
+  dependencies:
+    "@jest/test-result" "^26.6.0"
+    "@jest/types" "^26.6.0"
     "@types/node" "*"
     ansi-escapes "^4.2.1"
     chalk "^4.0.0"
-    jest-util "^26.5.2"
+    jest-util "^26.6.0"
     string-length "^4.0.1"
 
 jest-worker@^26.5.0:
@@ -3921,14 +4359,14 @@ jest-worker@^26.5.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jest@^26.5.3:
-  version "26.5.3"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-26.5.3.tgz#5e7a322d16f558dc565ca97639e85993ef5affe6"
-  integrity sha512-uJi3FuVSLmkZrWvaDyaVTZGLL8WcfynbRnFXyAHuEtYiSZ+ijDDIMOw1ytmftK+y/+OdAtsG9QrtbF7WIBmOyA==
+jest@^26.6.0:
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-26.6.0.tgz#546b25a1d8c888569dbbe93cae131748086a4a25"
+  integrity sha512-jxTmrvuecVISvKFFhOkjsWRZV7sFqdSUAd1ajOKY+/QE/aLBVstsJ/dX8GczLzwiT6ZEwwmZqtCUHLHHQVzcfA==
   dependencies:
-    "@jest/core" "^26.5.3"
+    "@jest/core" "^26.6.0"
     import-local "^3.0.2"
-    jest-cli "^26.5.3"
+    jest-cli "^26.6.0"
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -4731,6 +5169,16 @@ pretty-format@^26.5.2:
   integrity sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==
   dependencies:
     "@jest/types" "^26.5.2"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^16.12.0"
+
+pretty-format@^26.6.0:
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.0.tgz#1e1030e3c70e3ac1c568a5fd15627671ea159391"
+  integrity sha512-Uumr9URVB7bm6SbaByXtx+zGlS+0loDkFMHP0kHahMjmfCtmFY03iqd++5v3Ld6iB5TocVXlBN/T+DXMn9d4BA==
+  dependencies:
+    "@jest/types" "^26.6.0"
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
     react-is "^16.12.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1955,7 +1955,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.0.0:
+chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
   integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==


### PR DESCRIPTION
closes #37 

- [x] add `printCoverageSummary` config option to print coverage information
- [x] use chalk for logging

<img width="551" alt="Screenshot 2020-10-20 at 15 53 19" src="https://user-images.githubusercontent.com/6061509/96597381-104e1080-12ee-11eb-96a9-b5656696cf04.png">
