### PR TITLE
Split mock responses

### DIFF
--- a/packages/jest-mock-environment/README.md
+++ b/packages/jest-mock-environment/README.md
@@ -35,16 +35,17 @@ See a more detailed example in the [Jest Mock example package](https://github.co
 
 Using the Jest config `testEnvironmentOptions` you have the following options:
 
-#### mockResponsePath (required)
+#### mockResponseDir (required)
 
 Relative path to the `rootDir` in your config to store and load the recorded responses.
+The mocks will be saved using the specs' relative path with the postfix `.mocks.json`.
 
 Example:
 
 ```json
 {
   "testEnvironmentOptions": {
-    "mockResponsePath": "mocks/responses.json"
+    "mockResponseDir": "mocks"
   }
 }
 ```

--- a/packages/jest-mock-environment/package.json
+++ b/packages/jest-mock-environment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chealt/jest-mock-environment",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "MIT",
   "main": "index.js",
   "repository": {

--- a/packages/jest-mock-environment/src/envUtils.js
+++ b/packages/jest-mock-environment/src/envUtils.js
@@ -20,7 +20,7 @@ const filterEmptyResponses = (responses) => {
 
 const getMocks = (responsesPath) => require(responsesPath);
 
-const getFullPath = (rootDir, relativePath) => path.join(rootDir, relativePath);
+const getFullPath = (...paths) => path.join(...paths);
 
 const hasResponses = (responses) => Object.keys(responses).length;
 
@@ -29,8 +29,8 @@ const validateConfig = (config) => {
     throw new Error('You need to specify the `rootDir` in your jest config!');
   } else if (!config.testEnvironmentOptions) {
     throw new Error('You need to specify the `testEnvironmentOptions` in your jest config!');
-  } else if (!config.testEnvironmentOptions.mockResponsePath) {
-    throw new Error('Please specify where the mocks should be saved to and loaded from using the `mockResponsePath` test environment option.');
+  } else if (!config.testEnvironmentOptions.mockResponseDir) {
+    throw new Error('Please specify where the mocks should be saved to and loaded from using the `mockResponseDir` test environment option.');
   } else if (config.testEnvironmentOptions.collectCoverage && !config.testEnvironmentOptions.coverageDirectory) {
     throw new Error('When coverage is collected you need to provide a coverageDirectory option.');
   } else if (config.testEnvironmentOptions.recordScreenshots && !config.testEnvironmentOptions.screenshotDirectory) {
@@ -42,7 +42,7 @@ const validateConfig = (config) => {
         collectCoverage,
         collectCoverageFrom,
         coverageDirectory,
-        mockResponsePath,
+        mockResponseDir,
         printCoverageSummary,
         recordCoverageText,
         recordScreenshots,
@@ -55,7 +55,7 @@ const validateConfig = (config) => {
       collectCoverage,
       collectCoverageFrom,
       coverageDirectory,
-      mockResponsePath,
+      mockResponseDir,
       printCoverageSummary,
       recordCoverageText,
       rootDir,

--- a/packages/jest-mock-environment/src/factory.js
+++ b/packages/jest-mock-environment/src/factory.js
@@ -1,10 +1,6 @@
-const fs = require('fs');
-const { promisify } = require('util');
-
 const { findMocksForUrl } = require('./mockUtils');
 const { startCollecting, getCoverage } = require('./coverage/index');
-
-const writeFile = promisify(fs.writeFile);
+const { writeFileSafe } = require('./fileUtils');
 
 const factory = async ({ config: configParam, page, mocks, logger } = {}) => {
   let runningTestName;
@@ -204,10 +200,11 @@ const factory = async ({ config: configParam, page, mocks, logger } = {}) => {
     const trace = JSON.parse(await String(buffer));
     const screenshotEvents = trace.traceEvents.filter((event) => event.name === 'Screenshot');
 
-    return Promise.all(screenshotEvents.map(async (screenshotEvent, index) => {
+    return Promise.all(screenshotEvents.map((screenshotEvent, index) => {
       const imageBuffer = Buffer.from(screenshotEvent.args.snapshot, 'base64');
       const screenshotPath = `${screenshotFullPath}/${runningTestName.replace(/\//gu, '--')}-${index}.png`;
-      await writeFile(screenshotPath, imageBuffer);
+
+      return writeFileSafe(screenshotPath, imageBuffer);
     }));
   };
 

--- a/packages/jest-mock-environment/src/fileUtils.js
+++ b/packages/jest-mock-environment/src/fileUtils.js
@@ -1,0 +1,17 @@
+const path = require('path');
+const fs = require('fs');
+const { promisify } = require('util');
+
+const writeFile = promisify(fs.writeFile);
+const mkdir = promisify(fs.mkdir);
+
+const writeFileSafe = async (filepath, content) => {
+  const dirname = path.dirname(filepath);
+  await mkdir(dirname, { recursive: true });
+
+  return writeFile(filepath, content);
+};
+
+module.exports = {
+  writeFileSafe
+};

--- a/packages/jest-mock-environment/src/state.js
+++ b/packages/jest-mock-environment/src/state.js
@@ -1,8 +1,5 @@
-const fs = require('fs');
-const { promisify } = require('util');
+const { writeFileSafe } = require('./fileUtils');
 const coverageUtils = require('./coverage/utils');
-
-const writeFile = promisify(fs.writeFile);
 
 let allResponses = {};
 let allCodeCoverages = {};
@@ -19,16 +16,18 @@ const state = () => {
   };
   // RESPONSES
   let responsesPath;
-  const saveResponsesFile = (responses) =>
-    writeFile(responsesPath, JSON.stringify(responses));
-  const setResponsesPath = (path) => {
-    responsesPath = path;
+  const saveResponsesFile = (responses) => writeFileSafe(responsesPath, JSON.stringify(responses));
+  const setResponsesPath = (newPath) => {
+    responsesPath = newPath;
   };
   const addTestResponses = (responses) => {
     allResponses = {
       ...allResponses,
       ...responses
     };
+  };
+  const clearResponses = () => {
+    allResponses = {};
   };
   const getResponses = () => allResponses;
   const saveResponses = async () => {
@@ -38,9 +37,9 @@ const state = () => {
   // COVERAGES
   let coveragesPath;
   const saveCoveragesFile = (coverages) =>
-    writeFile(coveragesPath, JSON.stringify(coverages));
-  const setCoveragesPath = (path) => {
-    coveragesPath = path;
+    writeFileSafe(coveragesPath, JSON.stringify(coverages));
+  const setCoveragesPath = (newPath) => {
+    coveragesPath = newPath;
   };
   const addCodeCoverages = (coverages) => {
     allCodeCoverages = {
@@ -65,6 +64,7 @@ const state = () => {
     setLogger,
     // RESPONSES
     addTestResponses,
+    clearResponses,
     getResponses,
     saveResponses,
     setResponsesPath,

--- a/packages/jest-mock-environment/src/teardown.js
+++ b/packages/jest-mock-environment/src/teardown.js
@@ -1,14 +1,8 @@
 const { teardown: teardownPuppeteer } = require('jest-environment-puppeteer');
 
-const { saveResponses, saveCoverages, printCoverages } = require('./state');
-
-const { MOCK } = process.env;
+const { saveCoverages, printCoverages } = require('./state');
 
 const globalTeardown = async (globalConfig) => {
-  if (!MOCK) {
-    await saveResponses();
-  }
-
   await saveCoverages();
   printCoverages();
 

--- a/packages/jest-mock-example/config/jest/jest.puppeteer.config.js
+++ b/packages/jest-mock-example/config/jest/jest.puppeteer.config.js
@@ -4,7 +4,7 @@ module.exports = {
   verbose: !process.env.CI,
   testEnvironmentOptions: {
     isHostAgnostic: true,
-    mockResponsePath: 'mocks/responses.json',
+    mockResponseDir: 'mocks',
     shouldUseMocks: Boolean(process.env.MOCK),
     collectCoverage: true,
     coverageDirectory: 'coverage',

--- a/packages/jest-mock-example/package.json
+++ b/packages/jest-mock-example/package.json
@@ -12,7 +12,7 @@
     "test": "JEST_PUPPETEER_CONFIG=./config/puppeteer/puppeteer.config.js jest --runInBand --config=./config/jest/jest.puppeteer.config.js"
   },
   "dependencies": {
-    "@chealt/jest-puppeteer-mock-preset": "^0.7.0",
+    "@chealt/jest-puppeteer-mock-preset": "^0.8.0",
     "puppeteer": "^5.4.0"
   },
   "peerDependencies": {

--- a/packages/jest-puppeteer-mock-preset/package.json
+++ b/packages/jest-puppeteer-mock-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chealt/jest-puppeteer-mock-preset",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   "homepage": "https://github.com/chealt/chealt#chealt",
   "scripts": {},
   "dependencies": {
-    "@chealt/jest-mock-environment": "^0.9.0",
+    "@chealt/jest-mock-environment": "^0.10.0",
     "expect-puppeteer": "^4.4.0",
     "jest-circus": "^26.6.3"
   },


### PR DESCRIPTION
closes #42 

- [x] split mock responses using the specs' filename
- [x] introduce new config option `mockResponseDir`
- [x] create file util for saving files when folders don't exist