### PR TITLE
Add perf metrics summary and network condition emulation

### DIFF
--- a/packages/jest-puppeteer-env-example/config/jest/jest.puppeteer.config.js
+++ b/packages/jest-puppeteer-env-example/config/jest/jest.puppeteer.config.js
@@ -26,7 +26,9 @@ module.exports = {
           maxSize: '10 B'
         }
       ],
-      failOnBundleSizeViolation: false
+      failOnBundleSizeViolation: false,
+      // slowCPU: true,
+      emulateNetwork: 'Slow3G' // Fast3G, Slow3G
     },
     isHostAgnostic: true,
     mockResponseDir: 'mocks',

--- a/packages/jest-puppeteer-env-example/package.json
+++ b/packages/jest-puppeteer-env-example/package.json
@@ -12,7 +12,7 @@
     "test": "JEST_PUPPETEER_CONFIG=./config/puppeteer/puppeteer.config.js jest --runInBand --config=./config/jest/jest.puppeteer.config.js"
   },
   "dependencies": {
-    "@chealt/jest-puppeteer-env": "4.5.0",
+    "@chealt/jest-puppeteer-env": "4.6.0",
     "puppeteer": "10.4.0"
   },
   "peerDependencies": {

--- a/packages/jest-puppeteer-env/README.md
+++ b/packages/jest-puppeteer-env/README.md
@@ -246,6 +246,13 @@ Default: `false`
 
 Indicates whether the bundle size violations should fail the test.
 
+##### emulateNetwork
+
+Type: `String`
+Default: `undefined`
+
+Network conditions to simulate. Options are: `Fast3G`, `Slow3G`.
+
 #### Accessibility
 
 ##### failLevel

--- a/packages/jest-puppeteer-env/package.json
+++ b/packages/jest-puppeteer-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chealt/jest-puppeteer-env",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "license": "MIT",
   "main": "index.js",
   "repository": {

--- a/packages/jest-puppeteer-env/src/configUtils.js
+++ b/packages/jest-puppeteer-env/src/configUtils.js
@@ -3,6 +3,7 @@ const path = require('path');
 const { promisify } = require('util');
 const cwd = require('cwd');
 const merge = require('merge-deep');
+const { networks } = require('./performance/utils');
 
 const exists = promisify(fs.exists);
 
@@ -134,6 +135,17 @@ const validatePerformanceConfig = (config) => {
 
   if (performance.bundleSizes && !performance.reportDirectory) {
     throw new Error('When bundle size violations are collected you need to provide a reportDirectory option.');
+  }
+
+  if (
+    performance.emulateNetwork &&
+    !Object.keys(networks).some((networkName) => networkName === performance.emulateNetwork)
+  ) {
+    throw new Error(
+      `Unknown network to emulate: '${performance.emulateNetwork}', please use one of the following: ${Object.keys(
+        networks
+      ).join(', ')}`
+    );
   }
 };
 

--- a/packages/jest-puppeteer-env/src/performance/index.js
+++ b/packages/jest-puppeteer-env/src/performance/index.js
@@ -1,8 +1,20 @@
 const { checkBundleSize: checkBundleSizeFactory } = require('./bundleSize');
-const { getMetricsSummary } = require('./utils');
+const { getMetricsSummary, networks } = require('./utils');
 
 const performance = async ({ page, client, config }) => {
   const enabling = client.send('Performance.enable');
+  await client.send('Network.enable');
+  await client.send('ServiceWorker.enable');
+
+  if (config.performance.slowCPU) {
+    await client.send('Emulation.setCPUThrottlingRate', { rate: 4 });
+  }
+
+  if (config.performance.emulateNetwork) {
+    const networkConditions = networks[config.performance.emulateNetwork];
+
+    await client.send('Network.emulateNetworkConditions', networkConditions);
+  }
 
   const getMetrics = () =>
     Promise.all([

--- a/packages/jest-puppeteer-env/src/performance/index.js
+++ b/packages/jest-puppeteer-env/src/performance/index.js
@@ -1,4 +1,5 @@
 const { checkBundleSize: checkBundleSizeFactory } = require('./bundleSize');
+const { getMetricsSummary } = require('./utils');
 
 const performance = async ({ page, client, config }) => {
   const enabling = client.send('Performance.enable');
@@ -8,11 +9,16 @@ const performance = async ({ page, client, config }) => {
       page.evaluate(() => JSON.stringify(window.performance.getEntries())),
       enabling.then(() => client.send('Performance.getMetrics')).then(({ metrics }) => metrics),
       page.metrics()
-    ]).then(([entries, metrics, pageMetrics]) => ({
-      entries: JSON.parse(entries),
-      metrics,
-      pageMetrics
-    }));
+    ]).then(([rawEntries, metrics, pageMetrics]) => {
+      const entries = JSON.parse(rawEntries);
+
+      return {
+        entries,
+        metrics,
+        pageMetrics,
+        summary: getMetricsSummary({ entries })
+      };
+    });
 
   const checkBundleSize = config.performance?.bundleSizes
     ? checkBundleSizeFactory({ bundleSizes: config.performance.bundleSizes })

--- a/packages/jest-puppeteer-env/src/performance/utils.js
+++ b/packages/jest-puppeteer-env/src/performance/utils.js
@@ -22,4 +22,19 @@ const getMetricsSummary = (metrics) => {
   return summary;
 };
 
-module.exports = { getMetricsSummary };
+const networks = {
+  Fast3G: {
+    offline: false,
+    downloadThroughput: (1.5 * 1024 * 1024) / 8,
+    uploadThroughput: (750 * 1024) / 8,
+    latency: 40
+  },
+  Slow3G: {
+    offline: false,
+    downloadThroughput: (750 * 1024) / 8,
+    uploadThroughput: (250 * 1024) / 8,
+    latency: 100
+  }
+};
+
+module.exports = { getMetricsSummary, networks };

--- a/packages/jest-puppeteer-env/src/performance/utils.js
+++ b/packages/jest-puppeteer-env/src/performance/utils.js
@@ -1,0 +1,25 @@
+const getMetricsSummary = (metrics) => {
+  const summary = {};
+
+  if (metrics.entries) {
+    const firstPaint = metrics.entries.find((entry) => entry.name === 'first-paint');
+    const firstContentfulPaint = metrics.entries.find((entry) => entry.name === 'first-contentful-paint');
+
+    summary.firstPaint = firstPaint.startTime;
+    summary.firstContentfulPaint = firstContentfulPaint.startTime;
+
+    const navigationMetrics = metrics.entries.find((entry) => entry.entryType === 'navigation');
+
+    if (navigationMetrics) {
+      summary.domCompleted = navigationMetrics.duration;
+      summary.DNSLookup = navigationMetrics.domainLookupEnd - navigationMetrics.domainLookupStart;
+      summary.connectionTime = navigationMetrics.connectEnd - navigationMetrics.connectStart;
+      summary.responseTime = navigationMetrics.requestStart - navigationMetrics.responseEnd;
+      summary.domInteractive = navigationMetrics.domInteractive - navigationMetrics.responseEnd;
+    }
+  }
+
+  return summary;
+};
+
+module.exports = { getMetricsSummary };

--- a/packages/jest-puppeteer-env/src/performance/utils.js
+++ b/packages/jest-puppeteer-env/src/performance/utils.js
@@ -14,7 +14,7 @@ const getMetricsSummary = (metrics) => {
       summary.domCompleted = navigationMetrics.duration;
       summary.DNSLookup = navigationMetrics.domainLookupEnd - navigationMetrics.domainLookupStart;
       summary.connectionTime = navigationMetrics.connectEnd - navigationMetrics.connectStart;
-      summary.responseTime = navigationMetrics.requestStart - navigationMetrics.responseEnd;
+      summary.responseTime = navigationMetrics.requestEnd - navigationMetrics.responseStart;
       summary.domInteractive = navigationMetrics.domInteractive - navigationMetrics.responseEnd;
     }
   }


### PR DESCRIPTION
- add a summary to performance metrics
```json
{
  "summary": {
    "firstPaint": 522.8999999910593,
    "firstContentfulPaint": 522.8999999910593,
    "domCompleted": 3263.3999999910593,
    "DNSLookup": 0,
    "connectionTime": 0,
    "responseTime": null,
    "domInteractive": 32
  }
}
```
- add config to emulate network conditions Fast 3G or Slow 3G